### PR TITLE
[11.0][FIX] mdc: WOUT unexpected error when using an unused joker card

### DIFF
--- a/mdc/__manifest__.py
+++ b/mdc/__manifest__.py
@@ -14,7 +14,7 @@
 
     'category': 'Manufacturing',
     'license': 'LGPL-3',
-    'version': '0.1',
+    'version': '1.1',
 
     'depends': ['base', 'product', 'hr', 'hr_contract', 'stock', 'report_xlsx', 'base_external_dbsource_mysql'],
 

--- a/mdc/i18n/mdc.pot
+++ b/mdc/i18n/mdc.pot
@@ -18,19 +18,19 @@ msgstr ""
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_product_variant_count
 msgid "# Product Variants"
-msgstr "# Variantes de producto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_search
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_tree
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_tree
 msgid "#id"
-msgstr "#id"
+msgstr ""
 
 #. module: mdc
 #: selection:mdc.scale,scale_protocol:0
 msgid "$ Protocol"
-msgstr "Protocolo $"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:159
@@ -39,7 +39,7 @@ msgstr "Protocolo $"
 #: code:addons/mdc/report/report_xlsx.py:1018
 #, python-format
 msgid "% Backs"
-msgstr "% Lomos"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:161
@@ -48,7 +48,7 @@ msgstr "% Lomos"
 #: code:addons/mdc/report/report_xlsx.py:1019
 #, python-format
 msgid "% Crumbs"
-msgstr "% Migas"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:162
@@ -56,48 +56,48 @@ msgstr "% Migas"
 #: code:addons/mdc/report/report_xlsx.py:1020
 #, python-format
 msgid "% Total Yield"
-msgstr "% Rdto. Total"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:1022
 #, python-format
 msgid "% Waste"
-msgstr "% Merma"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A2V9
 msgid "+2.5"
-msgstr "+2.5"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A2V7
 msgid "-1.8"
-msgstr "-1.8"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A2V8
 msgid "1.8/2.5"
-msgstr "1.8/2.5"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A2V4
 msgid "10"
-msgstr "+10"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A2V2
 msgid "3/6"
-msgstr "3/6"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A2V6
 msgid "5/10"
-msgstr "5/10"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A2V3
 msgid "6/10"
-msgstr "6/10"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_lot_assignment
@@ -108,13 +108,7 @@ msgid "<span id=\"t_cardlot_device_err\">there is no device selected</span>\n"
 "            <span id=\"t_cardlot_card_waiting\">Assigning card...</span>\n"
 "            <span id=\"t_cardlot_success\">Card #{0} successfully assigned to lot {1}</span>\n"
 "            <span id=\"t_cardlot_err_unknown\">ERROR assigning card to lot (unknown)</span>"
-msgstr "<span id=\"t_cardlot_device_err\">no hay dispositivo seleccionado</span>\n"
-"            <span id=\"t_cardlot_lot_err\">no hay lote seleccionado</span>\n"
-"            <span id=\"t_cardlot_slide_err\">primero pase la tarjeta</span>\n"
-"            <span id=\"t_cardlot_card_info\">Leer tarjeta #{0}</span>\n"
-"            <span id=\"t_cardlot_card_waiting\">Asignando tarjeta...</span>\n"
-"            <span id=\"t_cardlot_success\">Tarjeta #{0} correctamente asignada a lote {1}</span>\n"
-"            <span id=\"t_cardlot_err_unknown\">ERROR asignando tarjeta a lote (desconocido)</span>"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_win
@@ -123,11 +117,7 @@ msgid "<span id=\"t_chkpoint_win_read_card\">Read card #{0}</span>\n"
 "            <span id=\"t_chkpoint_win_lot_err_unknown\">ERROR retrieving active lot (unknown)</span>\n"
 "            <span id=\"t_chkpoint_win_save_err_unknown\">ERROR registering weight (unknown)</span>\n"
 "            <span id=\"t_chkpoint_win_save_ok\">Data successfully saved</span>"
-msgstr "<span id=\"t_chkpoint_win_read_card\">Leer tarjeta #{0}</span>\n"
-"            <span id=\"t_chkpoint_win_lot_err\">ERROR recuperando lote activo: {0}</span>\n"
-"            <span id=\"t_chkpoint_win_lot_err_unknown\">ERROR recuperando lote activo (desconocido)</span>\n"
-"            <span id=\"t_chkpoint_win_save_err_unknown\">ERROR registrando peso (desconocido)</span>\n"
-"            <span id=\"t_chkpoint_win_save_ok\">Datos grabados correctamente</span>"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_wout
@@ -145,41 +135,28 @@ msgid "<span id=\"t_chkpoint_wout_jc_description\">Joker card</span>\n"
 "            <span id=\"t_chkpoint_wout_save_ok\">Weight saved successfully</span>\n"
 "            <span id=\"t_chkpoint_wout_save_err\">ERROR saving data: {0}</span>\n"
 "            <span id=\"t_chkpoint_wout_save_err_unknown\">ERROR saving data (unknown)</span>"
-msgstr "<span id=\"t_chkpoint_wout_jc_description\">Tarjeta Comodín</span>\n"
-"            <span id=\"t_chkpoint_wout_input_workstation_expected_err\">Tarjeta #{0} no válida. Se espera tarjeta de puesto</span>\n"
-"            <span id=\"t_chkpoint_wout_input_repeated_err\">Tarjeta #{0} ya fue leída!</span>\n"
-"            <span id=\"t_chkpoint_wout_input_no_input_err\">Tarjeta #{0} no válida, no existe entrada asociada!</span>\n"
-"            <span id=\"t_chkpoint_wout_jc_no_lot_err\">Tarjeta comodín #{0} no válida, no existe lote asociado. Primero pase una tarjeta de producto</span>\n"
-"            <span id=\"t_chkpoint_wout_input_lot_err\">Tarjeta leída #{0} corresponde a un lote diferente ({1}) al actual</span>\n"
-"            <span id=\"t_chkpoint_wout_input_one_input_already_selected_err\">Tarjeta de producto #{0} no válida. Seleccionado modo de entrada 1!</span>\n"
-"            <span id=\"t_chkpoint_wout_input_jc_added\">Tarjeta de producto/comodín añadida. Tarjeta #{0}</span>\n"
-"            <span id=\"t_chkpoint_wout_workstation_input_expected_err\">Tarjeta #{0} no válida. Se espera tarjeta de producto</span>\n"
-"            <span id=\"t_chkpoint_wout_workstation_no_workstation_err\">Tarjeta #{0} no válida, no existe puesto asociado!</span>\n"
-"            <span id=\"t_chkpoint_wout_invalid_card_err\">Tarjeta #{0} no válida</span>            <span id=\"t_chkpoint_wout_save_ok\">Peso grabado con éxito</span>\n"
-"            <span id=\"t_chkpoint_wout_save_err\">ERROR guardando datos: {0}</span>\n"
-"            <span id=\"t_chkpoint_wout_save_err_unknown\">ERROR guardando datos (desconocido)</span>"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_rfid_base
 msgid "<span id=\"t_ws_rfid_onopen_wait\">Waiting for websocket acceptance...</span>\n"
 "                    <span id=\"t_ws_rfid_onopen_ready\">Ready for card readings!!!</span>"
-msgstr "<span id=\"t_ws_rfid_onopen_wait\">Esperando por websocket...</span>\n"
-"                    <span id=\"t_ws_rfid_onopen_ready\">Preparado para leer tarjetas!!!</span>"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_description_sale
 msgid "A description of the Product that you want to communicate to your customers. This description will be copied to every Sales Order, Delivery Order and Customer Invoice/Credit Note"
-msgstr "Una descripción del producto que quiera comunicar a sus clientes. Esta descripción se copiará a cada pedido de venta, albarán de salida y factura de cliente."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_description_purchase
 msgid "A description of the Product that you want to communicate to your vendors. This description will be copied to every Purchase Order, Receipt and Vendor Bill/Credit Note."
-msgstr "Una descripción del producto que quiere comunicar a sus proveedores. Esta descripción se reflejará en todos los pedidos de compra, recibos y facturas de proveedor."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_description
 msgid "A precise description of the Product, used only for internal information purposes."
-msgstr "Una descripción precisa del producto, usada sólo para propósitos de información interna."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_type
@@ -187,15 +164,12 @@ msgid "A stockable product is a product for which you manage stock. The \"Invent
 "A consumable product, on the other hand, is a product for which stock is not managed.\n"
 "A service is a non-material product you provide.\n"
 "A digital content is a non-material product you sell online. The files attached to the products are the one that are sold on the e-commerce such as e-books, music, pictures,... The \"Digital Product\" module has to be installed."
-msgstr "Un producto almacenable es un producto para el que usted gestiona el stock. La aplicación \"Inventario\" debe instalarse.\n"
-"Por el contrario, un producto consumible es un producto para el que no se gestiona el stock.\n"
-"Un servicio es un producto no material que usted proporciona.\n"
-"Un contenido digital es un producto no material que vende en línea. Los archivos adjuntos a los productos son los que se venden en el comercio electrónico, tales como libros electrónicos, música, fotos, ... El módulo \"Producto Digital\" debe instalado."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_needaction
 msgid "Action Needed"
-msgstr "Acción requerida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_card_active
@@ -207,106 +181,106 @@ msgstr "Acción requerida"
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_active
 #: model:ir.model.fields,field_description:mdc.field_mdc_tare_active
 msgid "Active"
-msgstr "Activo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_lot_active
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_actives_form
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_actives_search
 msgid "Active Lot"
-msgstr "Lote activo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lot_chkpoint_form
 msgid "Active Lot per Check Point and Shift"
-msgstr "Lote Activo por Punto de Control y Turno"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_lots_actives
 #: model:ir.ui.menu,name:mdc.mdc_lot_active_menu
 msgid "Active Lots"
-msgstr "Lotes en Curso"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_form
 msgid "Active and Expiration Dates"
-msgstr "Fechas de activación y caducidad"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_activity_ids
 msgid "Activities"
-msgstr "Actividades"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_alias_cp
 msgid "Alias CP name"
-msgstr "Alias en punto de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_search
 msgid "All"
-msgstr "Todos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_chkpoint_allowed_ip
 msgid "Allowed IP"
-msgstr "IP permitida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_tree
 msgid "Are you sure to cancel this input? This will release the related card"
-msgstr "Está seguro de cancelar esta entrada? Esto liberará las tarjetas relacionadas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_lot_assignment
 msgid "Assign lot"
-msgstr "Asignar lote"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_lot_assignment
 msgid "Assigned lot"
-msgstr "Lote asignado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_card_lot_id
 msgid "Associated MO"
-msgstr "OF Asociada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_attribute_value_ids
 msgid "Attributes"
-msgstr "Atributos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 msgid "Audit data"
-msgstr "Auditar datos"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P9
 msgid "BACORETA"
-msgstr "BACORETA"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P4
 msgid "BIG EYE"
-msgstr "BIG EYE"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P19
 msgid "BIG EYE (OBESUS)"
-msgstr "BIG EYE (OBESUS)"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P1
 msgid "BONITO"
-msgstr "BONITO"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P20
 msgid "BONITO SARDA"
-msgstr "BONITO SARDA"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:152
@@ -319,33 +293,33 @@ msgstr "BONITO SARDA"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_product_weight
 #, python-format
 msgid "Backs"
-msgstr "Lomos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_barcode
 msgid "Barcode"
-msgstr "Código de barras"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_base_structure
 msgid "Base Structure model"
-msgstr "Modelo Base Structure"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_list_price
 msgid "Base price to compute the customer price. Sometimes called the catalog price."
-msgstr "Precio base para calcular el precio de los clientes. A veces llamado precio de catálogo."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_image
 msgid "Big-sized image"
-msgstr "Imagen grande"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:27
 #, python-format
 msgid "Blocked"
-msgstr "Bloqueado"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:171
@@ -356,7 +330,7 @@ msgstr "Bloqueado"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_product_boxes
 #, python-format
 msgid "Box Backs"
-msgstr "Cajas Lomos"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:172
@@ -367,48 +341,48 @@ msgstr "Cajas Lomos"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_sp1_boxes
 #, python-format
 msgid "Box Crumbs"
-msgstr "Cajas Migas"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P10
 msgid "CABALLA"
-msgstr "CABALLA"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P14
 msgid "CARNE DE ATUN"
-msgstr "CARNE DE ATUN"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P13
 msgid "COGOTES"
-msgstr "COGOTES"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P21
 msgid "CUARTOS BONITO"
-msgstr "CUARTOS BONITO"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:1001
 #, python-format
 msgid "CUMULATIVE REPORT"
-msgstr "INFORME ACUMULADO"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_purchase_ok
 msgid "Can be Purchased"
-msgstr "Puede ser comprado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_rental
 msgid "Can be Rent"
-msgstr "Puede ser alquilado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_sale_ok
 msgid "Can be Sold"
-msgstr "Puede ser vendido"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_rpt_cumulative
@@ -416,7 +390,7 @@ msgstr "Puede ser vendido"
 #: model:ir.actions.act_window,help:mdc.action_mdc_rpt_manufacturing
 #: model:ir.actions.act_window,help:mdc.action_mdc_rpt_tracing
 msgid "Can't create or update records in this view."
-msgstr "Imposible crear o actualizar registros en esta vista."
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.hr_employee_massworksheetclose_wizard_form
@@ -424,57 +398,57 @@ msgstr "Imposible crear o actualizar registros en esta vista."
 #: model:ir.ui.view,arch_db:mdc.mdc_config_settings_view_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_tree
 msgid "Cancel"
-msgstr "Cancelar"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_win_cancel_datetime
 msgid "Cancel date"
-msgstr "Cancelar fecha"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 msgid "Cancel input"
-msgstr "Cancelar entrada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_search
 msgid "Cancelled"
-msgstr "Cancelado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_win_cancel_user_id
 msgid "Cancelled by"
-msgstr "Cancelado por"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_tree
 msgid "Cancels this input"
-msgstr "Cancelar esta entrada"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:136
 #, python-format
 msgid "Cannot cancel input '%s - %s - %s' because it's been already linked with an output"
-msgstr "No puede cancelar la entrada '%s - %s - %s' porque ha sido vinculada a una salida"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/hr.py:196
 #, python-format
 msgid "Cannot create close worksheet: employee %s is not present"
-msgstr "No es posible cerrar fichaje: el empleado %s no está presente"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/hr.py:184
 #, python-format
 msgid "Cannot create open worksheet: employee %s is already present"
-msgstr "No es podible abrir fichaje: el empleado %s ya está presente"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 msgid "Capture Data"
-msgstr "Fecha de captura"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_card
@@ -484,31 +458,31 @@ msgstr "Fecha de captura"
 #: model:ir.ui.view,arch_db:mdc.mdc_card_tree
 #: model:ir.ui.view,arch_db:mdc.mdc_tare_tree
 msgid "Card"
-msgstr "Tarjeta"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:355
 #, python-format
 msgid "Card #%s comes from a different lot (current: %s)"
-msgstr "La Tarjeta #%s procede de diferente lote (actual: %s)"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:352
 #, python-format
 msgid "Card #%s is associated with inputs %s. Please cancel one of them"
-msgstr "La tarjeta %s está asociada con las entradas %s. Por favor, cancele una de ellas"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:355
 #, python-format
 msgid "Card #%s is not a joker card!"
-msgstr "La Tarjeta #%s no es una tarjeta comodín!"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:1009
 #, python-format
 msgid "Card #%s is not an employee one"
-msgstr "La Tarjeta #%s no es de empleado"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:112
@@ -516,53 +490,53 @@ msgstr "La Tarjeta #%s no es de empleado"
 #: code:addons/mdc/models/structure.py:353
 #, python-format
 msgid "Card #%s not found"
-msgstr "Tarjeta #%s no encontrada"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:369
 #, python-format
 msgid "Card #%s not valid: there's not any employee assigned with"
-msgstr "Tarjeta #%s no válida: no existe ningún operario asignado a ella"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:361
 #, python-format
 msgid "Card #%s not valid: there's not open input data linked with"
-msgstr "Tarjeta #%s no válida: no hay ningún dato de entrada vinculado con ella"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_cards_form
 msgid "Card Assignment"
-msgstr "Asignación de tarjetas"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:420
 #: sql_constraint:mdc.card_categ:0
 #, python-format
 msgid "Card Categ Code has been already assigned to a Card Categ!"
-msgstr "Código de Tipo de Tarjeta ya ha sido asignado a un Tipo de Tarjeta!"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_card_categ_menu
 msgid "Card Categories"
-msgstr "Tipos de tarjetas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_card_categ
 #: model:ir.ui.view,arch_db:mdc.mdc_card_categ_form
 #: model:ir.ui.view,arch_db:mdc.mdc_card_categ_tree
 msgid "Card Category"
-msgstr "Tipo de tarjeta"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_cards_form
 msgid "Card Status"
-msgstr "Estado de tarjeta"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_registration
 msgid "Card category"
-msgstr "Tipo de tarjeta"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/controllers/check_point.py:236
@@ -573,101 +547,101 @@ msgstr "Tipo de tarjeta"
 #: model:ir.ui.view,arch_db:mdc.mdc_card_lot_assign_tree
 #, python-format
 msgid "Card lot assignment"
-msgstr "Tarjetas Comodín-Lote"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:339
 #, python-format
 msgid "Card not valid (#%s)"
-msgstr "Tarjeta no válida (#%s)"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/controllers/check_point.py:197
 #: model:ir.ui.view,arch_db:mdc.chkpoint_list
 #, python-format
 msgid "Card registration"
-msgstr "Registro de tarjeta"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_card_card_categ_id
 msgid "Card_Categ"
-msgstr "Tipo Tarj."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_card_name
 msgid "Card_Code"
-msgstr "Código Tarj."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_card
 #: model:ir.ui.menu,name:mdc.mdc_card_menu
 #: model:ir.ui.view,arch_db:mdc.mdc_cards_form
 msgid "Cards"
-msgstr "Tarjetas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_card_categ
 msgid "Cards Categories"
-msgstr "Tipos de tarjetas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_route_from_categ_ids
 msgid "Category Routes"
-msgstr "Rutas de categoría"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_chkpoint
 #: model:ir.ui.view,arch_db:mdc.mdc_chkpoint_form
 #: model:ir.ui.view,arch_db:mdc.mdc_chkpoint_tree
 msgid "Check Point"
-msgstr "Punto de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lot_chkpoint_search
 msgid "Check Point Active Lot"
-msgstr "Lote activo en punto de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 msgid "Check Point Data"
-msgstr "Datos del punto de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lot_chkpoint_tree
 msgid "Check Point Lots Actives"
-msgstr "Lotes activos en puntos de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_chkpoint
 #: model:ir.ui.menu,name:mdc.mdc_chkpoint_menu
 msgid "Check Points"
-msgstr "Puntos de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_lot_chkpoint
 msgid "Check Points Lots Actives"
-msgstr "Lotes activos en puntos de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_chkpoint_form
 msgid "Check point current lot"
-msgstr "Lote actual en punto de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_chkpoint_form
 msgid "Check point data"
-msgstr "Datos del punto de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_chkpoint_form
 msgid "Check point parameters"
-msgstr "Parámetros del punto de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_chkpoint_chkpoint_id
 msgid "Checkpoint"
-msgstr "Punto de Control"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/controllers/check_point.py:103
@@ -675,54 +649,54 @@ msgstr "Punto de Control"
 #: code:addons/mdc/models/chkpointdata.py:482
 #, python-format
 msgid "Checkpoint #%s not found"
-msgstr "Punto de control #%s no encontrado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_chkpoint_chkpoint_categ
 msgid "Checkpoint Category"
-msgstr "Tipo de punto de control"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_active_chkpoint_id
 msgid "Checkpoint Id"
-msgstr "Identificador de punto de control"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:146
 #: code:addons/mdc/report/report_xlsx.py:483
 #, python-format
 msgid "Cleaning"
-msgstr "Limpieza"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_lots_actives
 msgid "Click to active lots or close lots."
-msgstr "Click para activar lotes o cerrar lotes."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_worksheets
 msgid "Click to create new worksheets."
-msgstr "Click para crear nuevos marcajes."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_workstations
 msgid "Click to create new workstations."
-msgstr "Click para crear nuevos puestos."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_lot_chkpoint
 msgid "Click to register new Check Points Lots Actives."
-msgstr "Click para crear nuevo Lote Activo por Punto de Control y Turno"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_lots
 msgid "Click to register new lots."
-msgstr "Click para registrar nuevos lotes."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_scales
 msgid "Click to register weghing scales."
-msgstr "Click para registrar básculas."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:147
@@ -733,57 +707,57 @@ msgstr "Click para registrar básculas."
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_client_name
 #, python-format
 msgid "Client"
-msgstr "Cliente"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_card_categ_code
 #: model:ir.model.fields,field_description:mdc.field_mdc_quality_code
 #: model:ir.model.fields,field_description:mdc.field_mdc_wout_categ_code
 msgid "Code"
-msgstr "Código"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_indicators_coef_weight_lot
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_coef_weight_lot
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_coef_weight_lot
 msgid "Coef Weight Lot"
-msgstr "Coef Peso Lote"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_color
 msgid "Color Index"
-msgstr "Índice de color"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:1167
 #: sql_constraint:mdc.lot_chkpoint:0
 #, python-format
 msgid "Combination: Checkpoint & Shift, are unique, and already Exists!"
-msgstr "Combinación: Punto de Control y Turno, son ÚNICOS, y ya existen!"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:61
 #: sql_constraint:mdc.chkpoint:0
 #, python-format
 msgid "Combination: Line & Checkpoint category, are unique, and already Exists!"
-msgstr "Combinación: Línea y Tipo de punto de control, son ÚNICOS, y ya existen!"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_company_id
 msgid "Company"
-msgstr "Compañía"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_menu_configuration
 msgid "Configuration"
-msgstr "Configuración"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:140
 #: code:addons/mdc/report/report_xlsx.py:477
 #, python-format
 msgid "Contract"
-msgstr "Contrato"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_cumulative_contract_name
@@ -792,46 +766,46 @@ msgstr "Contrato"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_contract_name
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_manufacturing_search
 msgid "Contract Name"
-msgstr "Nombre de contrato"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_contract_type_id
 msgid "Contract Type"
-msgstr "Tipo de contrato"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:149
 #: code:addons/mdc/report/report_xlsx.py:486
 #, python-format
 msgid "Cooking yield"
-msgstr "Rdto. Cocción"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:150
 #: code:addons/mdc/report/report_xlsx.py:487
 #, python-format
 msgid "Cooking yield Std"
-msgstr "STD Rdto. Cocción"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_standard_price
 msgid "Cost"
-msgstr "Precio de coste"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_standard_price
 msgid "Cost used for stock valuation in standard price and as a first price to set in average/fifo. Also used as a base price for pricelists. Expressed in the default unit of measure of the product."
-msgstr "Precio de coste utilizado para la valoración de existencias en precio estándar y como primer precio para establecer en promedio/fifo. También se utiliza como precio base para las tarifas. Expresado en la unidad de medida predeterminada del producto."
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.hr_employee_massworksheetclose_wizard_form
 msgid "Create close worksheets"
-msgstr "Crear cierre de fichaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.hr_employee_massworksheetopen_wizard_form
 msgid "Create open worksheets"
-msgstr "Crear apertura de fichaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard_create_uid
@@ -856,7 +830,7 @@ msgstr "Crear apertura de fichaje"
 #: model:ir.model.fields,field_description:mdc.field_mdc_workstation_create_uid
 #: model:ir.model.fields,field_description:mdc.field_mdc_wout_categ_create_uid
 msgid "Created by"
-msgstr "Creado por"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard_create_date
@@ -881,7 +855,7 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:mdc.field_mdc_workstation_create_date
 #: model:ir.model.fields,field_description:mdc.field_mdc_wout_categ_create_date
 msgid "Created on"
-msgstr "Creado el"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:153
@@ -894,7 +868,7 @@ msgstr "Creado el"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_sp1_weight
 #, python-format
 msgid "Crumbs"
-msgstr "Migas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_rpt_cumulative
@@ -903,18 +877,18 @@ msgstr "Migas"
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_cumulative_search
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_cumulative_tree
 msgid "Cumulative Report"
-msgstr "Informe Acumulado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_currency_id
 msgid "Currency"
-msgstr "Moneda"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_chkpoint_current_lot_active_id
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_chkpoint_current_lot_active_id
 msgid "Current MO Active Id"
-msgstr "Identificador de OF en Curso"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_qty_available
@@ -923,77 +897,74 @@ msgid "Current quantity of products.\n"
 "In a context with a single Warehouse, this includes goods stored in the Stock Location of this Warehouse, or any of its children.\n"
 "stored in the Stock Location of the Warehouse of this Shop, or any of its children.\n"
 "Otherwise, this includes goods stored in any Stock Location with 'internal' type."
-msgstr "Cantidad actual de los productos.\n"
-"En un contexto de una sola ubicación de Stock, esto incluye los bienes almacenados en esta ubicación, o cualquiera de sus hijas.\n"
-"En un contexto de un solo almacén, esto incluye los bienes almacenados en la ubicación de Stock de ese almacén, o cualquiera de sus hijas.\n"
-"En cualquier otro caso, esto incluye los bienes almacenados en cualquier ubicación de Stock de tipo 'Interna'."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_partner_id
 msgid "Customer"
-msgstr "Cliente"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_sale_delay
 msgid "Customer Lead Time"
-msgstr "Plazo de entrega del cliente"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_partner_ref
 msgid "Customer Ref"
-msgstr "Ref. Cliente"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_customer_menu
 msgid "Customers"
-msgstr "Cliente"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_menu_data
 msgid "Data"
-msgstr "Datos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_data_wins
 msgid "Data In"
-msgstr "Datos de entrada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_data_wouts
 msgid "Data Out"
-msgstr "Datos de salida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_data_win_menu
 msgid "Data in"
-msgstr "Entradas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_data_wout_menu
 msgid "Data out"
-msgstr "Salidas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_search
 msgid "Data_wOUT"
-msgstr "Datos de salida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_search
 msgid "Data_win"
-msgstr "Datos de entrada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_tree
 msgid "Data_wins"
-msgstr "Datos de entrada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_tree
 msgid "Data_wouts"
-msgstr "Datos de salida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_cumulative_create_date
@@ -1001,7 +972,7 @@ msgstr "Datos de salida"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_create_date
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_create_date
 msgid "Date"
-msgstr "Fecha"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:132
@@ -1009,93 +980,93 @@ msgstr "Fecha"
 #: code:addons/mdc/report/report_xlsx.py:1004
 #, python-format
 msgid "Date From:"
-msgstr "Fecha desde:"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:1143
 #, python-format
 msgid "Date From: %s to %s"
-msgstr "Fecha desde: %s hasta %s"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_message_last_post
 msgid "Date of the last message posted on the record."
-msgstr "Fecha del último mensaje publicado en el registro."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:1145
 #, python-format
 msgid "Date: #%s"
-msgstr "Fecha: #%s"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_win_create_datetime
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_wout_create_datetime
 msgid "Datetime"
-msgstr "Fecha-Hora"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_active_end_datetime
 msgid "Datetime_End"
-msgstr "Hora final"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_active_start_datetime
 msgid "Datetime_Start"
-msgstr "Hora inicial"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_uom_id
 msgid "Default Unit of Measure used for all stock operation."
-msgstr "Unidad de medida por defecto utilizada para todas las operaciones de stock."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_uom_po_id
 msgid "Default Unit of Measure used for purchase orders. It must be in the same category than the default unit of measure."
-msgstr "Unidad de medida predeterminada utilizada para los pedidos de compra. Debe estar en la misma categoría que la unidad de medida predeterminada."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_route_ids
 msgid "Depending on the modules installed, this will allow you to define the route of the product: whether it will be bought, manufactured, MTO/MTS,..."
-msgstr "Dependiendo de los módulos instalados, este permite definir la ruta del producto: si será comprado, facturado, bajo pedido o desde stock..."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_description
 msgid "Description"
-msgstr "Descripción"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_description_pickingout
 msgid "Description on Delivery Orders"
-msgstr "Descripción en los pedidos de Entrega"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_description_picking
 msgid "Description on Picking"
-msgstr "Descripción en Albarán"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_description_pickingin
 msgid "Description on Receptions"
-msgstr "Descripción en Recepciones"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_lot_assignment
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_registration
 msgid "Device"
-msgstr "Dispositivo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rfid_reader_device_code
 msgid "Device Code"
-msgstr "Código de dispositivo"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:502
 #: sql_constraint:mdc.rfid_reader:0
 #, python-format
 msgid "Device_Code has been already assigned to a Device!"
-msgstr "Código de dispositivo ya asignado a un dispositivo!"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard_display_name
@@ -1129,12 +1100,12 @@ msgstr "Código de dispositivo ya asignado a un dispositivo!"
 #: model:ir.model.fields,field_description:mdc.field_report_mdc_rpt_manufacturing_display_name
 #: model:ir.model.fields,field_description:mdc.field_report_mdc_rpt_tracing_display_name
 msgid "Display Name"
-msgstr "Nombre a mostrar"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A1V2
 msgid "Doble"
-msgstr "Doble"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_hr_employee
@@ -1146,7 +1117,7 @@ msgstr "Doble"
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_search
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
 msgid "Employee"
-msgstr "Empleado"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:138
@@ -1163,7 +1134,7 @@ msgstr "Empleado"
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_search
 #, python-format
 msgid "Employee Code"
-msgstr "Código de empleado"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:141
@@ -1173,7 +1144,7 @@ msgstr "Código de empleado"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_employee_date_start
 #, python-format
 msgid "Employee Incorporation date"
-msgstr "Fecha incorporación del empleado"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:139
@@ -1186,60 +1157,60 @@ msgstr "Fecha incorporación del empleado"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_employee_name
 #, python-format
 msgid "Employee Name"
-msgstr "Nombre de empleado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_employee_code
 msgid "Employee code"
-msgstr "Código de empleado"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/hr.py:19
 #: sql_constraint:hr.employee:0
 #, python-format
 msgid "Employee code must be unique!"
-msgstr "Código de empleado debe ser ÚNICO!"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_graph
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_pivot
 msgid "Employee evolution"
-msgstr "Evolución del empleado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_hr_employee_massworksheetclose_wizard
 msgid "Employee massive worksheet close wizard"
-msgstr "Asistente de Cierre masivo de fichajes"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_hr_employee_massworksheetopen_wizard
 msgid "Employee massive worksheet open wizard"
-msgstr "Asistente de Apertura masiva de fichajes"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:143
 #: code:addons/mdc/report/report_xlsx.py:480
 #, python-format
 msgid "Employee seniority"
-msgstr "Antigüedad"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard_employee_ids
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetopen_wizard_employee_ids
 #: model:ir.ui.menu,name:mdc.mdc_employee_menu
 msgid "Employees"
-msgstr "Empleados"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_shift_end_time
 msgid "End"
-msgstr "Fin"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard_end_datetime
 #: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_end_datetime
 msgid "End Datetime"
-msgstr "Hora final"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:194
@@ -1247,42 +1218,42 @@ msgstr "Hora final"
 #: code:addons/mdc/models/morders.py:609
 #, python-format
 msgid "End date must be older than start date"
-msgstr "Fecha Fin debe ser posterior a Fecha Inicio"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_end_date
 msgid "End_Date"
-msgstr "Fecha Fin"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_hr_employee_massworksheetopen
 msgid "Every operator is already present."
-msgstr "Cada trabajador ya está presente."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_hr_employee_massworksheetclose
 msgid "Every operator is no present."
-msgstr "Cada trabajador no está presente."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_follower_ids
 msgid "Followers"
-msgstr "Seguidores"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_channel_ids
 msgid "Followers (Channels)"
-msgstr "Seguidores (Canales)"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_partner_ids
 msgid "Followers (Partners)"
-msgstr "Seguidores (Empresas)"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_virtual_available
 msgid "Forecast Quantity"
-msgstr "Cantidad prevista"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_virtual_available
@@ -1290,25 +1261,22 @@ msgid "Forecast quantity (computed as Quantity On Hand - Outgoing + Incoming)\n"
 "In a context with a single Stock Location, this includes goods stored in this location, or any of its children.\n"
 "In a context with a single Warehouse, this includes goods stored in the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods stored in any Stock Location with 'internal' type."
-msgstr "Cantidad prevista (calculada como cantidad a mano - saliente + entrante)\n"
-"En un contexto de una sola ubicación de stock, esto incluye los bienes almacenados en esta ubicación, o cualquiera de sus hijas.\n"
-"En un contexto de un solo almacén, esto incluye los bienes almacenados en la ubicación de stock de ese almacén, o cualquiera de sus hijas.\n"
-"En cualquier otro caso, esto incluye los bienes almacenados en cualquier ubicación de stock de tipo 'Interna'."
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_scales_form
 msgid "Get current weight"
-msgstr "Lee peso actual"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_packaging_ids
 msgid "Gives the different ways to package the same product."
-msgstr "Da las diferentes formas de empaquetar el mismo producto."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_sequence
 msgid "Gives the sequence order when displaying a product list"
-msgstr "Proporciona el orden de secuencia al mostrar una lista de productos"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:151
@@ -1320,7 +1288,7 @@ msgstr "Proporciona el orden de secuencia al mostrar una lista de productos"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_gross_weight
 #, python-format
 msgid "Gross"
-msgstr "Bruto"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:148
@@ -1331,12 +1299,12 @@ msgstr "Bruto"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_gross_weight_reference
 #, python-format
 msgid "Gross Reference"
-msgstr "Bruto Congelado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_wout_gross_weight
 msgid "Gross Weight"
-msgstr "Peso bruto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_search
@@ -1351,17 +1319,17 @@ msgstr "Peso bruto"
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
 #: model:ir.ui.view,arch_db:mdc.mdc_workstations_search
 msgid "Group By"
-msgstr "Agrupar por"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_historical_lot_active_menu
 msgid "Historical Used Lots"
-msgstr "Histórico de lotes"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_list
 msgid "Home"
-msgstr "Raíz"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard_id
@@ -1395,7 +1363,7 @@ msgstr "Raíz"
 #: model:ir.model.fields,field_description:mdc.field_report_mdc_rpt_manufacturing_id
 #: model:ir.model.fields,field_description:mdc.field_report_mdc_rpt_tracing_id
 msgid "ID"
-msgstr "ID (identificación)"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:166
@@ -1408,7 +1376,7 @@ msgstr "ID (identificación)"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_ind_backs
 #, python-format
 msgid "IND Backs"
-msgstr "IND Lomos"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:170
@@ -1421,7 +1389,7 @@ msgstr "IND Lomos"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_ind_cleaning
 #, python-format
 msgid "IND Cleaning"
-msgstr "IND Limpieza"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:168
@@ -1434,7 +1402,7 @@ msgstr "IND Limpieza"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_ind_crumbs
 #, python-format
 msgid "IND Crumbs"
-msgstr "IND Migas"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:167
@@ -1447,7 +1415,7 @@ msgstr "IND Migas"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_ind_mo
 #, python-format
 msgid "IND MO"
-msgstr "IND MO"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:169
@@ -1460,77 +1428,77 @@ msgstr "IND MO"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_ind_quality
 #, python-format
 msgid "IND Quality"
-msgstr "IND Calidad"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:772
 #, python-format
 msgid "INDICATORS REPORT"
-msgstr "INFORME DE INDICADORES"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rfid_reader_tcp_address_ip
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_tcp_address_ip
 msgid "IP Address"
-msgstr "Dirección IP"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rfid_reader_tcp_address_port
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_tcp_address_port
 msgid "IP Port"
-msgstr "Puerto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_std_id
 msgid "Id Standard"
-msgstr "Id Standard"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:26
 #, python-format
 msgid "Idle"
-msgstr "Libre"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_message_unread
 msgid "If checked new messages require your attention."
-msgstr "Si está marcado, hay nuevos mensajes que requieren su atención"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_message_needaction
 msgid "If checked, new messages require your attention."
-msgstr "Si está marcado hay nuevos mensajes que requieren su atención."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_image
 msgid "Image of the product variant (Big-sized image of product template if false). It is automatically resized as a 1024x1024px image, with aspect ratio preserved."
-msgstr "Imagen de la variante del producto (Imagen grande de la plantilla del producto en caso de que esté vacía). Se redimensionará automáticamente como una imagen 1024x1024px, manteniendo la proporción."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_image_medium
 msgid "Image of the product variant (Medium-sized image of product template if false)."
-msgstr "Imagen de la variante del producto (Imagen mediana de la plantilla del producto en caso de ser falso)."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_image_small
 msgid "Image of the product variant (Small-sized image of product template if false)."
-msgstr "Imagen de la variante del producto (Imagen pequeña de la plantilla del producto en caso de ser falso)."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:25
 #, python-format
 msgid "In Use"
-msgstr "En uso"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_search
 msgid "In force"
-msgstr "En vigor"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_incoming_qty
 msgid "Incoming"
-msgstr "Entrada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_rpt_indicators
@@ -1539,118 +1507,118 @@ msgstr "Entrada"
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_indicators_search
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_indicators_tree
 msgid "Indicators Report"
-msgstr "Informe de indicadores"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:236
 #: code:addons/mdc/models/structure.py:19
 #, python-format
 msgid "Input"
-msgstr "Entrada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_wout
 msgid "Input(s) read"
-msgstr "Entrada(s) leída"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute,name:mdc.mdc_product_attribute_A1
 msgid "Instr. Limpieza"
-msgstr "Instr. Limpieza"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A1V3
 msgid "Intermedia"
-msgstr "Intermedia"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_categ_id
 msgid "Internal Category"
-msgstr "Categoría interna"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_default_code
 msgid "Internal Reference"
-msgstr "Referencia interna"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_barcode
 msgid "International Article Number used for product identification."
-msgstr "Número de artículo internacional usado para la identificación de producto."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:114
 #, python-format
 msgid "Invalid Card #%s"
-msgstr "Tarjeta No válida #%s"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:395
 #, python-format
 msgid "Invalid joker card #%s. Before using it, please make at least an input for this line with lot %s"
-msgstr "Tarjeta comodín %s no válida. Antes de usarla, por favor realice al menos una entrada para esta línea con el lote %s"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_property_stock_inventory
 msgid "Inventory Location"
-msgstr "Ubicación de inventario"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_is_follower
 msgid "Is Follower"
-msgstr "Es un seguidor"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_is_product_variant
 msgid "Is a product variant"
-msgstr "Is una variante de producto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_operator
 msgid "Is operator"
-msgstr "Es operario"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:664
 #: code:addons/mdc/models/morders.py:778
 #, python-format
 msgid "It can´t be end datetime less than start date to employee %s"
-msgstr "No es posible fecha-hora final menor que fecha-hora inicial para el empleado %s"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:657
 #: code:addons/mdc/models/morders.py:773
 #, python-format
 msgid "It can´t be start datetime less than last end datetime to employee %s"
-msgstr "No es posible fecha-hora inicial menor que última fecha-hora final para el empleado %s"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/standards.py:51
 #, python-format
 msgid "It not possible to duplicate the record, please create a new one"
-msgstr "No es posible duplicar registros, por favor cree uno nuevo"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/hr.py:165
 #, python-format
 msgid "It's not allowed to delete employee code for an operator. If you want to set an automatic code, first unset operator check and save"
-msgstr "No está permitido borrar el código de empleado de un operario. Si desea establecer códigos automáticos, primero des-asigne el check de operario y luego grabe"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:426
 #, python-format
 msgid "It's not allowed to open a shared output without registering any product input"
-msgstr "No está permitido abrir una salida compartida sin registrar ninguna entrada"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P3
 msgid "LISTADO"
-msgstr "LISTADO"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_last_post
 msgid "Last Message Date"
-msgstr "Fecha del último mensaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard___last_update
@@ -1684,7 +1652,7 @@ msgstr "Fecha del último mensaje"
 #: model:ir.model.fields,field_description:mdc.field_report_mdc_rpt_manufacturing___last_update
 #: model:ir.model.fields,field_description:mdc.field_report_mdc_rpt_tracing___last_update
 msgid "Last Modified on"
-msgstr "Última modificación en"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard_write_uid
@@ -1709,7 +1677,7 @@ msgstr "Última modificación en"
 #: model:ir.model.fields,field_description:mdc.field_mdc_workstation_write_uid
 #: model:ir.model.fields,field_description:mdc.field_mdc_wout_categ_write_uid
 msgid "Last Updated by"
-msgstr "Última actualización de"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetclose_wizard_write_date
@@ -1734,74 +1702,74 @@ msgstr "Última actualización de"
 #: model:ir.model.fields,field_description:mdc.field_mdc_workstation_write_date
 #: model:ir.model.fields,field_description:mdc.field_mdc_wout_categ_write_date
 msgid "Last Updated on"
-msgstr "Última actualización en"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_card_lot_assign_tree
 msgid "Last assignment date"
-msgstr "Última fecha asignada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_win
 msgid "Last card read"
-msgstr "Última tarjeta leída"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_lot_assignment
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_registration
 msgid "Last card read:<br/>"
-msgstr "Última tarjeta leída:<br/>"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_workstation_last_wout_lot_id
 msgid "Last output lot processed"
-msgstr "Último lote de salida procesado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_last_physical_worksheet_end_datetime
 msgid "Last physical worksheet end datetime"
-msgstr "Última fecha fin de marcaje físico"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_last_physical_worksheet_start_datetime
 msgid "Last physical worksheet start datetime"
-msgstr "Última fecha inicio de marcaje físico"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_wout
 msgid "Last quality"
-msgstr "Última calidad"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_win
 #: model:ir.ui.view,arch_db:mdc.chkpoint_wout
 msgid "Last weight"
-msgstr "Último peso"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_last_weight_uom_id
 msgid "Last weight Unit"
-msgstr "Última unidad de medida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_scales_form
 msgid "Last weight data"
-msgstr "Última pesada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_last_weight_datetime
 msgid "Last weight date"
-msgstr "Última pesada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_last_weight_stability
 msgid "Last weight stability"
-msgstr "Última estabilización"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_last_weight_value
 msgid "Last weight value"
-msgstr "Último valor de pesada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_line
@@ -1816,40 +1784,40 @@ msgstr "Último valor de pesada"
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_actives_search
 #: model:ir.ui.view,arch_db:mdc.mdc_workstations_search
 msgid "Line"
-msgstr "Linea"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_line_line_code
 msgid "Line Code"
-msgstr "Código de línea"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_line_form
 msgid "Line data"
-msgstr "Datos de línea"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:40
 #: sql_constraint:mdc.line:0
 #, python-format
 msgid "Line_Code has been already assigned to a Line!"
-msgstr "Código de línea ya ha sido asignado a una línea!"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_line
 #: model:ir.ui.menu,name:mdc.mdc_line_menu
 msgid "Lines"
-msgstr "Líneas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_list
 msgid "List of available checkpoints for RFID simulation:"
-msgstr "Lista de puntos de control disponibles para simulación RFID:"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_location_id
 msgid "Location"
-msgstr "Ubicación"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_lot
@@ -1863,20 +1831,20 @@ msgstr "Ubicación"
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_search
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
 msgid "Lot"
-msgstr "Lote"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_actives_form
 #: model:ir.ui.view,arch_db:mdc.mdc_workstations_form
 msgid "Lot Activation"
-msgstr "Activación de lotes"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_indicators_lot_finished
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_lot_finished
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_lot_finished
 msgid "Lot Finished"
-msgstr "Lote Finalizado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_cumulative_search
@@ -1884,27 +1852,27 @@ msgstr "Lote Finalizado"
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_manufacturing_search
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_search
 msgid "Lot Name"
-msgstr "Nombre del lote"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_lot_chkpoint
 msgid "Lot active per Check Point and Shift"
-msgstr "Lote Activo por Punto de Control y Turno"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_finished
 msgid "Lot finished"
-msgstr "Lote Finalizado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_lot_last_total_gross_weight_update_timestamp
 msgid "Lot last total gross weight update timestamp"
-msgstr "Marca de tiempo de la última actualización de peso bruto de los lotes"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_form
 msgid "Lot parameters"
-msgstr "Parámetros del lote"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_lots
@@ -1913,87 +1881,87 @@ msgstr "Parámetros del lote"
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_form
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_tree
 msgid "Lots"
-msgstr "Lotes"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_config_settings_view_form
 msgid "Lots Parameters"
-msgstr "Parámetros de lote"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_lot_default_life_days
 msgid "Lots default life in days"
-msgstr "Días de vida por defecto de los lotes"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:466
 #, python-format
 msgid "MANUFACTURING REPORT"
-msgstr "INFORME DE FABRICACIÓN"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_list
 msgid "MCD CP:"
-msgstr "MCD CP:"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_menu_root
 msgid "MDC"
-msgstr "MDC"
+msgstr ""
 
 #. module: mdc
 #: model:res.groups,name:mdc.group_mdc_cp
 msgid "MDC Check Point"
-msgstr "Punto de Control MDC"
+msgstr ""
 
 #. module: mdc
 #: model:res.groups,name:mdc.group_mdc_manager
 msgid "MDC managers"
-msgstr "Gestor MDC"
+msgstr ""
 
 #. module: mdc
 #: model:res.groups,name:mdc.group_mdc_office_worker
 msgid "MDC office worker"
-msgstr "MDC empleado de oficina"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_config_settings
 #: model:ir.ui.view,arch_db:mdc.mdc_config_settings_view_form
 msgid "MDC settings"
-msgstr "Configuración MDC"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.server,name:mdc.ir_cron_lotactive_total_hours_ir_actions_server
 #: model:ir.cron,cron_name:mdc.ir_cron_lotactive_total_hours
 #: model:ir.cron,name:mdc.ir_cron_lotactive_total_hours
 msgid "MDC: Calculate total hours of lots without end date"
-msgstr "MDC: Calcula las horas totales de los lotes sin fecha final"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.server,name:mdc.ir_cron_data_win_close_ir_actions_server
 #: model:ir.cron,cron_name:mdc.ir_cron_data_win_close
 #: model:ir.cron,name:mdc.ir_cron_data_win_close
 msgid "MDC: Old unlinked inputs cancellation"
-msgstr "MDC: Cancelación de entradas antiguas no vinculadas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.server,name:mdc.ir_cron_lot_total_hours_ir_actions_server
 #: model:ir.cron,cron_name:mdc.ir_cron_lot_total_hours
 #: model:ir.cron,name:mdc.ir_cron_lot_total_hours
 msgid "MDC: Update lot total gross weight"
-msgstr "MDC: Actualización del total bruto por lote"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.server,name:mdc.ir_cron_worksheet_update_blind_worksheets_ir_actions_server
 #: model:ir.cron,cron_name:mdc.ir_cron_worksheet_update_blind_worksheets
 #: model:ir.cron,name:mdc.ir_cron_worksheet_update_blind_worksheets
 msgid "MDC: Worksheet update blind worksheets"
-msgstr "MDC: Worksheet update blind worksheets"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P5
 msgid "MELVA"
-msgstr "MELVA"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:144
@@ -2010,19 +1978,19 @@ msgstr "MELVA"
 #: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_lot_id
 #, python-format
 msgid "MO"
-msgstr "OF"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:142
 #, python-format
 msgid "MO Format is not right. The right format is NNNNN/AA (AA=current year) %s != %s"
-msgstr "Formato de OF no correcto. El formato correcto es NNNNN/AA (AA=año actual) %s != %s"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:140
 #, python-format
 msgid "MO Format is not right. The right format is NNNNN/AA (NNNNN=number)"
-msgstr "Formato de OF no correcto. El formato correcto es NNNNN/AA (NNNNN=número)"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:164
@@ -2031,7 +1999,7 @@ msgstr "Formato de OF no correcto. El formato correcto es NNNNN/AA (NNNNN=númer
 #: code:addons/mdc/report/report_xlsx.py:1024
 #, python-format
 msgid "MO."
-msgstr "MO."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_rpt_manufacturing
@@ -2040,7 +2008,7 @@ msgstr "MO."
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_manufacturing_search
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_manufacturing_tree
 msgid "Manufacturing Report"
-msgstr "Informe de Fabricación"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:142
@@ -2048,22 +2016,22 @@ msgstr "Informe de Fabricación"
 #: code:addons/mdc/report/report_xlsx.py:784
 #, python-format
 msgid "Manufacturing date"
-msgstr "Fecha Fabricación"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.server,name:mdc.action_view_workstations_mass_deallocation
 msgid "Masive de-allocation"
-msgstr "Desasignación múltiple"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_hr_employee_massworksheetclose
 msgid "Massive Worksheet close"
-msgstr "Fichajes. Fin Masivo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_hr_employee_massworksheetopen
 msgid "Massive Worksheet open"
-msgstr "Fichajes. Inicio Masivo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.server,name:mdc.action_view_hr_mass_worksheet_close
@@ -2071,7 +2039,7 @@ msgstr "Fichajes. Inicio Masivo"
 #: model:ir.ui.view,arch_db:mdc.hr_employee_massworksheetclose_wizard_form
 #: model:ir.ui.view,arch_db:mdc.hr_employee_tree_massworksheetclose
 msgid "Massive worksheet close"
-msgstr "Fichajes. Fin Masivo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.server,name:mdc.action_view_hr_mass_worksheet_open
@@ -2079,33 +2047,33 @@ msgstr "Fichajes. Fin Masivo"
 #: model:ir.ui.view,arch_db:mdc.hr_employee_massworksheetopen_wizard_form
 #: model:ir.ui.view,arch_db:mdc.hr_employee_tree_massworksheetopen
 msgid "Massive worksheet open"
-msgstr "Fichajes. Inicio Masivo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_menu_master
 msgid "Master Data"
-msgstr "Datos principales"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_image_medium
 msgid "Medium-sized image"
-msgstr "Imagen de tamaño mediano"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_ids
 msgid "Messages"
-msgstr "Mensajes"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_orderpoint_ids
 msgid "Minimum Stock Rules"
-msgstr "Reglas de stock mínimo"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:255
 #, python-format
 msgid "Modifying card category is not allowed. Please contact Administrator"
-msgstr "No está permitido modificar el Tipo de tarjeta. Por favor, contacte con el administrador"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_card_categ_name
@@ -2119,40 +2087,40 @@ msgstr "No está permitido modificar el Tipo de tarjeta. Por favor, contacte con
 #: model:ir.model.fields,field_description:mdc.field_mdc_tare_name
 #: model:ir.model.fields,field_description:mdc.field_mdc_wout_categ_name
 msgid "Name"
-msgstr "Nombre"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:314
 #, python-format
 msgid "Neither the lot nor the checkpoint not the sift can be modified"
-msgstr "Ni el lote, ni el punto de control, ni el turno pueder ser modificados"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:508
 #, python-format
 msgid "New RFID device"
-msgstr "Nuevo dispositivo RFID"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/scale.py:23
 #, python-format
 msgid "New scale"
-msgstr "Nueva báscula"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_activity_date_deadline
 msgid "Next Activity Deadline"
-msgstr "Siguiente plazo de actividad"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_activity_summary
 msgid "Next Activity Summary"
-msgstr "Resumen de la siguiente actividad"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_activity_type_id
 msgid "Next Activity Type"
-msgstr "Siguiente tipo de actividad"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_card_lotassign
@@ -2161,22 +2129,22 @@ msgstr "Siguiente tipo de actividad"
 #: model:ir.actions.act_window,help:mdc.action_mdc_rpt_manufacturing
 #: model:ir.actions.act_window,help:mdc.action_mdc_rpt_tracing
 msgid "Not possible."
-msgstr "No es posible."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_needaction_counter
 msgid "Number of Actions"
-msgstr "Número de acciones"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_message_needaction_counter
 msgid "Number of messages which requires an action"
-msgstr "Número de mensajes que requieren una acción"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_message_unread_counter
 msgid "Number of unread messages"
-msgstr "Número de mensajes no leidos"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:173
@@ -2187,135 +2155,135 @@ msgstr "Número de mensajes no leidos"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_lot_descrip
 #, python-format
 msgid "Observations"
-msgstr "Observaciones"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:365
 #, python-format
 msgid "Only one workstation card is allowed"
-msgstr "Sólo está permitida una tarjeta de puesto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_search
 msgid "Open"
-msgstr "Abierto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_menu_operations
 msgid "Operations"
-msgstr "Operaciones"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.hr_employee_form
 msgid "Operative Information"
-msgstr "Información de Operario"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.view_hr_employee_filter
 msgid "Operatives"
-msgstr "Operarios"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_form
 msgid "Other data"
-msgstr "Otros datos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_wout_categ_menu
 msgid "Out Categories"
-msgstr "Tipos de salida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_wout_categ
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_wout_wout_categ_id
 msgid "Out Category"
-msgstr "Tipos de Salida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_outgoing_qty
 msgid "Outgoing"
-msgstr "Saliente"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:237
 #: code:addons/mdc/models/structure.py:20
 #, python-format
 msgid "Output"
-msgstr "Salida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_tree
 msgid "P.C."
-msgstr "F.F."
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_tree
 msgid "P.O."
-msgstr "I.F."
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P11
 msgid "PALOMETA"
-msgstr "PALOMETA"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P17
 msgid "PEZ ESPADA"
-msgstr "PEZ ESPADA"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_search
 msgid "Partner"
-msgstr "Empresa"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_physical_close
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
 msgid "Physical close"
-msgstr "Cierre físico"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_physical_open
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
 msgid "Physical open"
-msgstr "Inicio físico"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_err
 msgid "Please contact with system administrator"
-msgstr "Por favor, contacte con el administrador del sistema"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.hr_employee_massworksheetclose_wizard_form
 #: model:ir.ui.view,arch_db:mdc.hr_employee_massworksheetopen_wizard_form
 msgid "Please select a start date and hour for the worksheets:"
-msgstr "Por favor, seleccione fecha y hora de inicio para el fichaje:"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_present
 #: model:ir.ui.view,arch_db:mdc.view_hr_employee_filter
 msgid "Present"
-msgstr "Presente"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_price
 msgid "Price"
-msgstr "Precio"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_pricelist_id
 msgid "Pricelist"
-msgstr "Lista de precios"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_pricelist_item_ids
 msgid "Pricelist Item"
-msgstr "Item de Lista de precios"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_item_ids
 msgid "Pricelist Items"
-msgstr "Items de Lista de precios"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.report,name:mdc.cumulative_xlsx
@@ -2323,7 +2291,7 @@ msgstr "Items de Lista de precios"
 #: model:ir.actions.report,name:mdc.manufacturing_xlsx
 #: model:ir.actions.report,name:mdc.tracing_xlsx
 msgid "Print to XLSX"
-msgstr "Exportar a Excel"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:145
@@ -2338,58 +2306,58 @@ msgstr "Exportar a Excel"
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_search
 #, python-format
 msgid "Product"
-msgstr "Producto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_product_id
 msgid "Product (Standard)"
-msgstr "Producto (Estándar)"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_attribute_line_ids
 msgid "Product Attributes"
-msgstr "Atributos del producto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 msgid "Product Category"
-msgstr "Tipos de producto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_packaging_ids
 msgid "Product Packages"
-msgstr "Paquetes de productos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_product_tmpl_id
 msgid "Product Template"
-msgstr "Plantilla de producto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_type
 msgid "Product Type"
-msgstr "Tipo de producto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_property_stock_production
 msgid "Production Location"
-msgstr "Ubicación de producción"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_product_variant_ids
 #: model:ir.ui.menu,name:mdc.mdc_product_menu
 msgid "Products"
-msgstr "Productos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_description_purchase
 msgid "Purchase Description"
-msgstr "Descripción de compra"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_uom_po_id
 msgid "Purchase Unit of Measure"
-msgstr "Unidad de medida de compra"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:157
@@ -2409,12 +2377,12 @@ msgstr "Unidad de medida de compra"
 #: model:ir.ui.view,arch_db:mdc.mdc_quality_tree
 #, python-format
 msgid "Quality"
-msgstr "Calidad"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_qty_available
 msgid "Quantity On Hand"
-msgstr "Cantidad a mano"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_incoming_qty
@@ -2422,10 +2390,7 @@ msgid "Quantity of planned incoming products.\n"
 "In a context with a single Stock Location, this includes goods arriving to this Location, or any of its children.\n"
 "In a context with a single Warehouse, this includes goods arriving to the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods arriving to any Stock Location with 'internal' type."
-msgstr "Cantidad de productos entrantes planificados.\n"
-"En un contexto con una única ubicación de stock, esto incluye los bienes que llegan a esta ubicación o cualquiera de sus hijos.\n"
-"En un contexto con un solo Almacén, esto incluye los bienes que llegan a la Ubicación de stock de este Almacén, o cualquiera de sus hijos.\n"
-"De lo contrario, esto incluye bienes que llegan a cualquier Ubicación de Stock con tipo 'interno'."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_outgoing_qty
@@ -2433,10 +2398,7 @@ msgid "Quantity of planned outgoing products.\n"
 "In a context with a single Stock Location, this includes goods leaving this Location, or any of its children.\n"
 "In a context with a single Warehouse, this includes goods leaving the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods leaving any Stock Location with 'internal' type."
-msgstr "Cantidad de productos salientes planificados.\n"
-"En un contexto con una única ubicación de stock, esto incluye bienes que salen de esta ubicación o cualquiera de sus hijos.\n"
-"En un contexto con un solo Almacén, esto incluye los bienes que salen de la Ubicación de stock de este Almacén, o cualquiera de sus hijos.\n"
-"De lo contrario, esto incluye bienes que salgan de cualquier Stock Stock con tipo 'interno'."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_rfid_reader
@@ -2444,139 +2406,139 @@ msgstr "Cantidad de productos salientes planificados.\n"
 #: model:ir.ui.view,arch_db:mdc.mdc_rfid_reader_form
 #: model:ir.ui.view,arch_db:mdc.mdc_rfid_reader_tree
 msgid "RFID Reader"
-msgstr "Lector RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_rfid_reader_form
 msgid "RFID Reader data"
-msgstr "Datos del lector RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_rfid_reader_form
 msgid "RFID Reader parameters"
-msgstr "Parámetros del lector RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_rfid_reader_menu
 msgid "RFID Readers"
-msgstr "Lectores RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_rfid_reader
 msgid "RFID Reades"
-msgstr "Lectores RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_rfid_server_password
 msgid "RFID Server Password"
-msgstr "Clave del servidor RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_rfid_server_url
 msgid "RFID Server URL"
-msgstr "URL del servidor RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_rfid_server_user
 msgid "RFID Server User"
-msgstr "Usuario del servidor RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_rfid_server_last_worksheet_timestamp
 msgid "RFID Server last worksheet timestamp"
-msgstr "Marca de tiempo del último fichaje del servidor RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_rfid_server_min_secs_between_worksheets
 msgid "RFID Server minimum seconds between worksheets"
-msgstr "Número de segundos mínimo entre marcajes del servidor RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_rfid_ws_server_url
 msgid "RFID WebSocket Server URL"
-msgstr "URL del servidor WebSocket RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_config_settings_view_form
 msgid "RFID server"
-msgstr "Servidor RFID"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 msgid "Read Cards"
-msgstr "Leer tarjetas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 msgid "Read in Data OUT"
-msgstr "Lectura a la salida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_physical_end_datetime
 msgid "Real End Datetime"
-msgstr "F. fin real"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_physical_start_datetime
 msgid "Real Start Datetime"
-msgstr "F. inicio real"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_total_gross_weight
 msgid "Real Total Gross Weight"
-msgstr "Peso Bruto en Línea"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_code
 msgid "Reference"
-msgstr "Referencia"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_registration
 msgid "Register card"
-msgstr "Registro de Tarjeta"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_reordering_max_qty
 msgid "Reordering Max Qty"
-msgstr " Abasteciendo cant. max."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_reordering_min_qty
 msgid "Reordering Min Qty"
-msgstr " Abasteciendo cant. min."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_nbr_reordering_rules
 msgid "Reordering Rules"
-msgstr "Reglas de abastecimiento"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_menu_reporting
 msgid "Reporting"
-msgstr "Informes"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_activity_user_id
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_responsible_id
 msgid "Responsible"
-msgstr "Responsable"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_route_ids
 msgid "Routes"
-msgstr "Rutas"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P18
 msgid "SALMON"
-msgstr "SALMON"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P8
 msgid "SARDA"
-msgstr "SARDA"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:160
@@ -2585,7 +2547,7 @@ msgstr "SARDA"
 #: code:addons/mdc/report/report_xlsx.py:1025
 #, python-format
 msgid "STD Back"
-msgstr "STD Lomos"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:163
@@ -2594,7 +2556,7 @@ msgstr "STD Lomos"
 #: code:addons/mdc/report/report_xlsx.py:1026
 #, python-format
 msgid "STD Crumbs"
-msgstr "STD Migas"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:165
@@ -2603,116 +2565,116 @@ msgstr "STD Migas"
 #: code:addons/mdc/report/report_xlsx.py:1027
 #, python-format
 msgid "STD MO"
-msgstr "STD MO"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_description_sale
 msgid "Sale Description"
-msgstr "Descripción de venta"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_lst_price
 msgid "Sale Price"
-msgstr "Precio de venta"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_list_price
 msgid "Sales Price"
-msgstr "Precio de venta"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_config_settings_view_form
 msgid "Save"
-msgstr "Guardar"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_chkpoint_scale_id
 msgid "Scale"
-msgstr "Báscula"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:98
 #: code:addons/mdc/models/chkpointdata.py:484
 #, python-format
 msgid "Scale not defined"
-msgstr "Báscula no definida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_scales_form
 msgid "Scale parameters"
-msgstr "Parámetros de báscula"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_scales_search
 msgid "Scale protocol"
-msgstr "Protocolo de báscula"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_workstation_seat
 msgid "Seat"
-msgstr "Asiento"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_registration
 msgid "Select a category..."
-msgstr "Seleccione un tipo..."
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_lot_assignment
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_registration
 msgid "Select a device..."
-msgstr "Seleccione un dispositivo..."
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_lot_assignment
 msgid "Select a lot..."
-msgstr "Seleccione un lote..."
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_registration
 msgid "Select a workstation..."
-msgstr "Seleccione un puesto..."
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_card_registration
 msgid "Select an employee..."
-msgstr "Seleccione un operario..."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_categ_id
 msgid "Select category for the current product"
-msgstr "Seleccione la categoría para el producto actual."
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A1V1
 msgid "Sencilla mejorada"
-msgstr "Sencilla mejorada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_sequence
 msgid "Sequence"
-msgstr "Secuencia"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_config_settings_view_form
 msgid "Server credentials"
-msgstr "Credenciales de servidor"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_config_settings_menu
 msgid "Settings"
-msgstr "Ajustes"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_wout_shared
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 msgid "Shared"
-msgstr "Compartida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_tree
 msgid "Shared #id"
-msgstr "Compartida #id"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_cumulative_shared_product_weight
@@ -2720,7 +2682,7 @@ msgstr "Compartida #id"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_shared_product_weight
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_shared_product_weight
 msgid "Shared Backs"
-msgstr "Lomos Compartidos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_cumulative_shared_sp1_weight
@@ -2728,7 +2690,7 @@ msgstr "Lomos Compartidos"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_shared_sp1_weight
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_shared_sp1_weight
 msgid "Shared Crumbs"
-msgstr "Migas Compartidas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_cumulative_shared_gross_weight
@@ -2736,29 +2698,29 @@ msgstr "Migas Compartidas"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_shared_gross_weight
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_shared_gross_weight
 msgid "Shared Gross"
-msgstr "Bruto Compartido"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_indicators_shared_gross_weight_reference
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_shared_gross_weight_reference
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_shared_gross_weight_reference
 msgid "Shared Gross Reference"
-msgstr "Bruto Compartido Congelado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_search
 msgid "Shared close"
-msgstr "Cierre Compartido"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_search
 msgid "Shared open"
-msgstr "Apertura Compartida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_wout_wout_shared_id
 msgid "Shared with"
-msgstr "Compartida con"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:782
@@ -2772,7 +2734,7 @@ msgstr "Compartida con"
 #: model:ir.ui.view,arch_db:mdc.mdc_shift_tree
 #, python-format
 msgid "Shift"
-msgstr "Turno"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:155
@@ -2780,7 +2742,7 @@ msgstr "Turno"
 #: code:addons/mdc/report/report_xlsx.py:1015
 #, python-format
 msgid "Shift Change Backs"
-msgstr "Lomos Cambio de Turno"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:156
@@ -2788,7 +2750,7 @@ msgstr "Lomos Cambio de Turno"
 #: code:addons/mdc/report/report_xlsx.py:1016
 #, python-format
 msgid "Shift Change Crumbs"
-msgstr "Migas Cambio de Turno"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:154
@@ -2796,7 +2758,7 @@ msgstr "Migas Cambio de Turno"
 #: code:addons/mdc/report/report_xlsx.py:1014
 #, python-format
 msgid "Shift Change Gross"
-msgstr "Bruto Cambio de Turno"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_indicators_shift_code
@@ -2807,65 +2769,65 @@ msgstr "Bruto Cambio de Turno"
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_manufacturing_search
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_search
 msgid "Shift Code"
-msgstr "Código de turno"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_shift_form
 msgid "Shift data"
-msgstr "Datos del turno"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_shift_form
 msgid "Shift time"
-msgstr "Horario del turno"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:375
 #: sql_constraint:mdc.shift:0
 #, python-format
 msgid "Shift_Code has been already assigned to a Shift!"
-msgstr "Código de turno ya ha sido asignado a un turno!"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_shift
 msgid "Shifts"
-msgstr "Turnos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_wout
 msgid "Sim. input"
-msgstr "Sim. entrada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_image_small
 msgid "Small-sized image"
-msgstr "Imagen de tamaño pequeño"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_sale_ok
 msgid "Specify if the product can be selected in a sales order line."
-msgstr "Especifique si un producto puede ser seleccionado en un pedido de venta."
+msgstr ""
 
 #. module: mdc
 #: selection:mdc.scale,last_weight_stability:0
 msgid "Stable"
-msgstr "Estable"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_stds_form
 msgid "Standard Detail"
-msgstr "Detalle del estándar"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_std_count
 #: model:ir.model.fields,field_description:mdc.field_product_product_std_count
 msgid "Standard count"
-msgstr "Standard count"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_form
 msgid "Standard data"
-msgstr "Datos Estándar"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_std
@@ -2874,44 +2836,44 @@ msgstr "Datos Estándar"
 #: model:ir.ui.view,arch_db:mdc.mdc_stds_form
 #: model:ir.ui.view,arch_db:mdc.mdc_stds_tree
 msgid "Standards"
-msgstr "Estándares"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_shift_start_time
 msgid "Start"
-msgstr "Inicio"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_start_date
 msgid "Start Date"
-msgstr "Fecha de inicio"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_massworksheetopen_wizard_start_datetime
 #: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_start_datetime
 msgid "Start Datetime"
-msgstr "Hora de inicio"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_chkpoint_start_lot_datetime
 msgid "Start MO Active date time"
-msgstr "Inicio activación de OF"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:294
 #, python-format
 msgid "Start date must be older last end date"
-msgstr "La fecha de inicio debe más antigua que la de fin"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_activity_state
 msgid "State"
-msgstr "Estado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_card_status
 msgid "Status"
-msgstr "Estado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_activity_state
@@ -2919,16 +2881,13 @@ msgid "Status based on activities\n"
 "Overdue: Due date is already passed\n"
 "Today: Activity date is today\n"
 "Planned: Future activities."
-msgstr "Estado basado en actividades\n"
-"Vencida: la fecha tope ya ha pasado\n"
-"Hoy: La fecha tope es hoy\n"
-"Planificada: futuras actividades."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_std_ids
 #: model:ir.model.fields,field_description:mdc.field_product_product_std_ids
 msgid "Std"
-msgstr "Std"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_std_loss
@@ -2937,7 +2896,7 @@ msgstr "Std"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_std_loss
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_std_loss
 msgid "Std Loss"
-msgstr "Merma Estimada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_std_speed
@@ -2947,7 +2906,7 @@ msgstr "Merma Estimada"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_std_speed
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_std_speed
 msgid "Std Speed"
-msgstr "STD Velocidad"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_std_yield_product
@@ -2957,7 +2916,7 @@ msgstr "STD Velocidad"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_std_yield_product
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_std_yield_product
 msgid "Std Yield Product"
-msgstr "STD Rdto. Producto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_std_yield_sp1
@@ -2967,50 +2926,50 @@ msgstr "STD Rdto. Producto"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_std_yield_sp1
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_std_yield_sp1
 msgid "Std Yield Subproduct 1"
-msgstr "STD Rdto. Migas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_std_yield_sp2
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_std_yield_sp2
 msgid "Std Yield Subproduct 2"
-msgstr "STD Rdto. Subproducto 2"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_std_yield_sp3
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_std_yield_sp3
 msgid "Std Yield Subproduct 3"
-msgstr "STD Rdto. Subproducto 3"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_stock_move_ids
 msgid "Stock Move"
-msgstr "Movimiento de Stock"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_stock_quant_ids
 msgid "Stock Quant"
-msgstr "Stock Quant"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:129
 #, python-format
 msgid "TRACING REPORT"
-msgstr "INFORME DE SEGUIMIENTO"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A1V4
 msgid "TRIPLE PLUS"
-msgstr "Triple +"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P15
 msgid "TROCITOS CRUDO"
-msgstr "TROCITOS CRUDO"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute,name:mdc.mdc_product_attribute_A2
 msgid "Tamaño"
-msgstr "Tamaño"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_tare
@@ -3020,146 +2979,146 @@ msgstr "Tamaño"
 #: model:ir.model.fields,field_description:mdc.field_mdc_tare_tare
 #: model:ir.ui.view,arch_db:mdc.mdc_tare_form
 msgid "Tare"
-msgstr "Tara"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_tare_uom_id
 msgid "Tare Unit"
-msgstr "Unidad de tara"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:100
 #: code:addons/mdc/models/chkpointdata.py:486
 #, python-format
 msgid "Tare not defined"
-msgstr "Tara no definida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_tare
 #: model:ir.ui.menu,name:mdc.mdc_tare_menu
 msgid "Tares"
-msgstr "Taras"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_pricelist_id
 msgid "Technical field. Used for searching on pricelists, not stored in database."
-msgstr "Campo técnico. Se utiliza para buscar en lista de precios, no almacenadas en la base de datos."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_stock_move_ids
 #: model:ir.model.fields,help:mdc.field_mdc_std_stock_quant_ids
 msgid "Technical: used to compute quantities."
-msgstr "Técnico: se utiliza para calcular las cantidades."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_sale_delay
 msgid "The average delay in days between the confirmation of the customer order and the delivery of the finished products. It's the time you promise to your customers."
-msgstr "El retraso medio en días entre la confirmación del pedido de cliente y la entrega de los productos finales. Es el tiempo que promete a sus clientes."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/controllers/check_point.py:33
 #, python-format
 msgid "The checkpoint %s is not allowed for this address (%s)"
-msgstr "El punto de control %s no está permitido para esta dirección (%s)"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:128
 #: sql_constraint:mdc.workstation:0
 #, python-format
 msgid "The employee has been already assigned to a workstation!"
-msgstr "El operario ya ha sido asignado a un puesto!"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:49
 #, python-format
 msgid "The lot default life days must be an integer!!"
-msgstr "Los días por defecto de vida de un lote debe de ser un entero!!"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:51
 #, python-format
 msgid "The lot default life days must be at least zero!!!"
-msgstr "Los días por defecto de vida de un lote deben ser al menos cero!!!"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:42
 #, python-format
 msgid "The minimum seconds between worksheets must be an integer!!"
-msgstr "El número mínimo de segundos entre marcajes debe ser un entero!!"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:44
 #, python-format
 msgid "The minimum seconds between worksheets must be bigger than 0!!!"
-msgstr "El número mínimo de segundos entre marcajes debe ser mayor de cero!!!"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_lst_price
 msgid "The sale price is managed from the product template. Click on the 'Variant Prices' button to set the extra attribute prices."
-msgstr "El precio de venta se gestiona desde la plantilla del producto. Haga clic en el botón 'Precios variantes' para establecer los precios adicionales de los atributos."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:63
 #: sql_constraint:mdc.chkpoint:0
 #, python-format
 msgid "The selected allowed IP is already assigned!"
-msgstr "La IP permitida seleccionada ya está asignada!"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:26
 #: sql_constraint:mdc.lot:0
 #, python-format
 msgid "The selected lot name already exists"
-msgstr "El nombre de lote seleccionado ya existe"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:660
 #, python-format
 msgid "The start date has to be filled"
-msgstr "Debe rellenar la Fecha de Inicio"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_volume
 msgid "The volume in m3."
-msgstr "El volumen en m3."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_weight
 msgid "The weight of the contents in Kg, not including any packaging, etc."
-msgstr "El peso del contenido en Kg, sin incluir empaquetado, etc..."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:79
 #, python-format
 msgid "There is already open data with the selected card (%s)"
-msgstr "Ya hay datos registrados en curso con la tarjeta (%s)"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:130
 #: sql_constraint:mdc.workstation:0
 #, python-format
 msgid "There's already a workstation with the same line, shift and seat values"
-msgstr "Ya existe un puesto con los mismos calores de: línea, turno y asiento"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:219
 #: sql_constraint:mdc.card:0
 #, python-format
 msgid "There's another card with the same code"
-msgstr "Ya existe otra tarjeta con el mismo código"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/standards.py:18
 #: sql_constraint:mdc.std:0
 #, python-format
 msgid "There's another standard with the same product"
-msgstr "Hay otro estándar con el mismo producto"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:96
 #, python-format
 msgid "There's not an active lot"
-msgstr "No hay ningún lote activo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_actives_search
@@ -3168,27 +3127,27 @@ msgstr "No hay ningún lote activo"
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_manufacturing_search
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_search
 msgid "This Week"
-msgstr "Semana actual"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_image_variant
 msgid "This field holds the image used as image for the product variant, limited to 1024x1024px."
-msgstr "Este campo contiene la imagen usada como imagen de la variante del producto, limitada a 1024x1024px."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_price_extra
 msgid "This is the sum of the extra price of all attributes"
-msgstr "Ésta es la suma de los precios extra de todos los atributos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_property_stock_production
 msgid "This stock location will be used, instead of the default one, as the source location for stock moves generated by manufacturing orders."
-msgstr "Se usará esta ubicación de stock, en lugar de la predeterminada, como la ubicación origen para los movimientos de stock generados por las órdenes de fabricación."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,help:mdc.field_mdc_std_property_stock_inventory
 msgid "This stock location will be used, instead of the default one, as the source location for stock moves generated when you do an inventory."
-msgstr "Se usará esta ubicación de existencias, en lugar de la predeterminada, como la ubicación origen para los movimientos de stock generados cuando se realizan inventarios."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:158
@@ -3197,19 +3156,19 @@ msgstr "Se usará esta ubicación de existencias, en lugar de la predeterminada,
 #: code:addons/mdc/report/report_xlsx.py:1023
 #, python-format
 msgid "Time"
-msgstr "Tiempo"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:104
 #: code:addons/mdc/models/chkpointdata.py:490
 #, python-format
 msgid "Timed out on weighing scale"
-msgstr "Superado tiempo de espera en báscula"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_timeout_secs
 msgid "Timeout (s)"
-msgstr "Tiempo de espera (s)"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_search
@@ -3220,7 +3179,7 @@ msgstr "Tiempo de espera (s)"
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_search
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
 msgid "Today"
-msgstr "Hoy"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_cumulative_total_hours
@@ -3228,18 +3187,18 @@ msgstr "Hoy"
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_total_hours
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_total_hours
 msgid "Total Hours"
-msgstr "Horas totales"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_cumulative_total_yield
 msgid "Total Yield"
-msgstr "Rendimiento Total"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_active_total_hours
 #: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_total_hours
 msgid "Total hours"
-msgstr "Horas totales"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_rpt_tracing
@@ -3248,187 +3207,187 @@ msgstr "Horas totales"
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_search
 #: model:ir.ui.view,arch_db:mdc.mdc_rpt_tracing_tree
 msgid "Tracing Report"
-msgstr "Informe de Seguimiento"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_tracking
 msgid "Tracking"
-msgstr "Seguimiento"
+msgstr ""
 
 #. module: mdc
 #: model:product.attribute.value,name:mdc.mdc_product_attribute_value_A1V5
 msgid "Triple"
-msgstr "Triple"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_tree
 msgid "Type"
-msgstr "Tipo"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_card_lotassign
 msgid "Unable to register new cards in this view."
-msgstr "Imposible registrar nuevas tarjetas en esta vista."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_uom_id
 msgid "Unit of Measure"
-msgstr "Unidad de medida"
+msgstr ""
 
 #. module: mdc
 #: selection:mdc.scale,last_weight_stability:0
 msgid "Unknown"
-msgstr "Desconocido"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:407
 #, python-format
 msgid "Unknown card #%s"
-msgstr "Tarjeta desconocida #%s"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:1011
 #, python-format
 msgid "Unknown card code #%s"
-msgstr "Código de tarjeta desconocido #%s"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/scale.py:117
 #, python-format
 msgid "Unknown data format. Data received: %s"
-msgstr "Formato de datos desconocido. Dato recibido: %s"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_unread
 msgid "Unread Messages"
-msgstr "Mensajes sin leer"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contador de mensajes sin leer"
+msgstr ""
 
 #. module: mdc
 #: selection:mdc.scale,last_weight_stability:0
 msgid "Unstable"
-msgstr "Inestable"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:107
 #, python-format
 msgid "Unstable %.2f %s weight was read. Please slide the card one more time"
-msgstr "Leída pesada inestable de %.2f %s. Por favor, pase la tarjeta de nuevo"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:493
 #, python-format
 msgid "Unstable %.2f %s weight was read. Please start passing cards again"
-msgstr "Leída pesada inestable de %.2f %s. Por favor, vuelva a pasar todas las tarjetas de nuevo"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/scale.py:99
 #, python-format
 msgid "Unsupported weighing protocol (%s)"
-msgstr "Protocolo de báscula No soportado (%s)"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P12
 msgid "VENTRESCA"
-msgstr "VENTRESCA"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_image_variant
 msgid "Variant Image"
-msgstr "Imagen de la variante"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_price_extra
 msgid "Variant Price Extra"
-msgstr "Precio adicional de la variante "
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_variant_seller_ids
 msgid "Variant Seller"
-msgstr "Variante del vendedor"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_seller_ids
 msgid "Vendors"
-msgstr "Proveedores"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_volume
 msgid "Volume"
-msgstr "Volumen"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:479
 #, python-format
 msgid "WOUT categ code #%s not found"
-msgstr "Código de tipo de Salida #%s no encontrado"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_win_wout_id
 msgid "WOut"
-msgstr "Salida"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_card_categ_form
 #: model:ir.ui.view,arch_db:mdc.mdc_wout_categ_form
 #: model:ir.ui.view,arch_db:mdc.mdc_wout_categ_tree
 msgid "WOut Category"
-msgstr "Tipos de salidas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.chkpoint_rfid_base
 msgid "Waiting for websocket connection..."
-msgstr "Esperando por la conexión al websocket..."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_warehouse_id
 msgid "Warehouse"
-msgstr "Almacén"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:1021
 #, python-format
 msgid "Waste"
-msgstr "Merma"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:406
 #, python-format
 msgid "We don´t find shift to this time %s"
-msgstr "No se encuentra turno para esta hora: %s"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:402
 #, python-format
 msgid "We find more than one shift to this time %s"
-msgstr "Encontrado más de un turno para esta hora %s"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_scale
 msgid "Weighing Scale"
-msgstr "Báscula"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_scale_protocol
 msgid "Weighing protocol"
-msgstr "Protocolo de Pesaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_scales_form
 #: model:ir.ui.view,arch_db:mdc.mdc_scales_search
 msgid "Weighing scale"
-msgstr "Báscula"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_scales
 #: model:ir.ui.menu,name:mdc.mdc_scale_menu
 #: model:ir.ui.view,arch_db:mdc.mdc_scales_tree
 msgid "Weighing scales"
-msgstr "Básculas"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_win_weight
@@ -3436,39 +3395,39 @@ msgstr "Básculas"
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_weight
 #: model:ir.model.fields,field_description:mdc.field_mdc_std_weight
 msgid "Weight"
-msgstr "Peso"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_data_win
 msgid "Weight Input Data"
-msgstr "Entrada de datos de pesada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_data_wout
 msgid "Weight Output Data"
-msgstr "salida de datos de pesada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_w_uom_id
 #: model:ir.model.fields,field_description:mdc.field_mdc_scale_weight_uom_id
 msgid "Weight Unit"
-msgstr "Unidad de peso"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_win_w_uom_id
 #: model:ir.model.fields,field_description:mdc.field_mdc_data_wout_w_uom_id
 msgid "Weight UoM"
-msgstr "Unidad de Medida de Pesada"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_hr_employee_massworksheetclose
 msgid "When an operator is unable to make his close worksheet, you'll find him here."
-msgstr "Cuando un operario no puede cerrar su fichaje, lo encontrará aquí."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_hr_employee_massworksheetopen
 msgid "When an operator is unable to make his open worksheet, you'll find him here."
-msgstr "Cuando un operario no puede abrir su fichaje, lo encontrará aquí."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.act_hr_employee_2_mdc_worksheet
@@ -3477,32 +3436,32 @@ msgstr "Cuando un operario no puede abrir su fichaje, lo encontrará aquí."
 #: model:ir.ui.view,arch_db:mdc.hr_employee_form
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
 msgid "Worksheet"
-msgstr "Fichaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_worksheet_end_datetime
 msgid "Worksheet End Datetime"
-msgstr "Fecha-Hora de fin de Fichaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_worksheet_status_start_datetime
 msgid "Worksheet Status Start Datetime"
-msgstr "Fecha-Hora de inicio de Estado de Fichaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_hr_employee_worksheet_status_data
 msgid "Worksheet Status data"
-msgstr "Datos de Estado de Fichaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_form
 msgid "Worksheet by Card"
-msgstr "Marcaje por tarjeta"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_form
 msgid "Worksheet data"
-msgstr "Datos de fichaje"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_worksheets
@@ -3511,7 +3470,7 @@ msgstr "Datos de fichaje"
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_form
 #: model:ir.ui.view,arch_db:mdc.mdc_worksheets_tree
 msgid "Worksheets"
-msgstr "Fichajes"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:137
@@ -3528,151 +3487,151 @@ msgstr "Fichajes"
 #: model:ir.ui.view,arch_db:mdc.mdc_workstations_search
 #, python-format
 msgid "Workstation"
-msgstr "Puesto"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:442
 #, python-format
 msgid "Workstation %s has not any output nor there is current lot in checkpoint, so it's not yet allowed to make a %s output"
-msgstr "El puesto %s no ha registrado una salida ni existe lote en vigor para el punto de control, por tanto no se puede hacer una salida de %s"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.menu,name:mdc.mdc_workstation_assign_menu
 msgid "Workstation Assign"
-msgstr "Asignación de Puestos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_indicators_workstation_name
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_manufacturing_workstation_name
 #: model:ir.model.fields,field_description:mdc.field_mdc_rpt_tracing_workstation_name
 msgid "Workstation Name"
-msgstr "Nombre del Puesto"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_workstations
 #: model:ir.ui.view,arch_db:mdc.mdc_workstations_tree
 msgid "Workstations"
-msgstr "Puestos"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_wout_ids
 msgid "Wout"
-msgstr "Wout"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:441
 #: sql_constraint:mdc.wout_categ:0
 #, python-format
 msgid "Wout Categ Code has been already assigned to a Wout Categ!"
-msgstr "El código de Tipo de Salida ya ha sido asignado a un Tipo de Salida!"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P2
 msgid "YELLOWFIN"
-msgstr "YELLOWFIN"
+msgstr ""
 
 #. module: mdc
 #: model:product.template,name:mdc.mdc_product_template_P16
 msgid "YELOWFIN COLAS "
-msgstr "YELOWFIN COLAS "
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:38
 #: code:addons/mdc/models/morders.py:793
 #, python-format
 msgid "You are not allowed to change this values"
-msgstr "No tiene permiso para cambiar este valor"
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_lots_actives
 msgid "You can active lots for in a line for each checkpoint."
-msgstr "Puede activar lotes para cada punto de control de cada línea."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_worksheets
 msgid "You can create n worksheet by line and shift."
-msgstr "Puede crear N fichajes por línea y turno."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_workstations
 msgid "You can create n workstation by line and shift."
-msgstr "Puede crear N puestos por línea y turno."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_lot_chkpoint
 msgid "You can register Lots Actives to existing Check Points."
-msgstr "Puede registrar el Lote Activo para un Punto de Control y Turno."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_lots
 msgid "You can register Lots and assign a product and a customer."
-msgstr "Puede registrar lotes y asignarles un producto y un cliente."
+msgstr ""
 
 #. module: mdc
 #: model:ir.actions.act_window,help:mdc.action_mdc_scales
 msgid "You can register and track weighing scales."
-msgstr "Puede registrar y testear básculas."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:753
 #, python-format
 msgid "You can´t change employee form a datasheet."
-msgstr "No puede cambiar el empleado desde un fichaje."
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:422
 #, python-format
 msgid "You can´t change end date because there are %s reg. in the interval of change"
-msgstr "No se puede cambiar la fecha fin porque hay %s regs. en el intervalo de cambio"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:363
 #, python-format
 msgid "You can´t change start date because there are %s reg. in the interval of change"
-msgstr "No se puede cambiar la fecha de inicio porque hay %s regs. en el intervalo de cambio"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:398
 #, python-format
 msgid "You can´t change this end datetime. You must change the start date of the active lot with start date this end date"
-msgstr "No se puede cambiar esta fecha fin. Se debe cambiar la fecha de inicio del lote activo con la fecha de inicio con esta fecha de fin"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:1196
 #, python-format
 msgid "You can´t establish a future datetime"
-msgstr "No se puede proporcionar una fecha futura"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:300
 #, python-format
 msgid "You can´t give a future end date"
-msgstr "No se puede proporcionar una fecha de fin future"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:288
 #: code:addons/mdc/models/morders.py:1244
 #, python-format
 msgid "You can´t give a future start date"
-msgstr "No se puede proporcionar una fecha futura de inicio"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:1201
 #, python-format
 msgid "You can´t give a lot in create mode"
-msgstr "No se puede poner el lote en el alta del registro"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:1205
 #, python-format
 msgid "You can´t give a start lot datetime in create mode"
-msgstr "No se puede poner la fecha de inicio en el alta del registro"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:450
 #, python-format
 msgid "You can´t put this date because there are %s reg. in after this"
-msgstr "No se puede poner esta fecha porque hay %s regs. después de esta"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:369
@@ -3680,101 +3639,101 @@ msgstr "No se puede poner esta fecha porque hay %s regs. después de esta"
 #: code:addons/mdc/models/morders.py:480
 #, python-format
 msgid "You don't have permissions to this operation"
-msgstr "No tiene permisos para esta operación"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/chkpointdata.py:410
 #, python-format
 msgid "You must provide a workstation card"
-msgstr "Debe proporcionar una tarjeta de puesto"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:263
 #, python-format
 msgid "You must select a workstation for this card"
-msgstr "Debe seleccionar un puesto para esta tarjeta"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:287
 #, python-format
 msgid "You must select a workstation for this card or select another category"
-msgstr "Debe seleccionar un puesto para esta tarjeta o elegir otro tipo"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:258
 #, python-format
 msgid "You must select an employee for this card"
-msgstr "Debe seleccionar un operario para esta tarjeta"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/structure.py:282
 #, python-format
 msgid "You must select an employee for this card or select another category"
-msgstr "Debe seleccionar un operario para esta tarjeta o elegir otro tipo"
+msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:1212
 #, python-format
 msgid "You must to have no lot assigned to delete this record"
-msgstr "No se puede tener un lote asignado para borrar el registro"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_lots_form
 msgid "_Observations..."
-msgstr "Anote aquí sus Observaciones ..."
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_config_settings
 msgid "mdc.config.settings"
-msgstr "mdc.config.settings"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_config_settings_view_form
 msgid "or"
-msgstr "o"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_chkpoint_order
 msgid "order"
-msgstr "orden"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_report_mdc_rpt_cumulative
 msgid "report.mdc.rpt_cumulative"
-msgstr "report.mdc.rpt_cumulative"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_report_mdc_rpt_indicators
 msgid "report.mdc.rpt_indicators"
-msgstr "report.mdc.rpt_indicators"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_report_mdc_rpt_manufacturing
 msgid "report.mdc.rpt_manufacturing"
-msgstr "report.mdc.rpt_manufacturing"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_report_mdc_rpt_tracing
 msgid "report.mdc.rpt_tracing"
-msgstr "report.mdc.rpt_tracing"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_res_config_settings
 msgid "res.config.settings"
-msgstr "res.config.settings"
+msgstr ""
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_workstations_search
 msgid "shift"
-msgstr "turno"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_lot_active_shift_id
 msgid "shift Id"
-msgstr "Turno"
+msgstr ""
 
 #. module: mdc
 #: model:ir.model,name:mdc.model_mdc_wout_categ
 msgid "wout Category"
-msgstr "Tipo de salida"
+msgstr ""
 

--- a/mdc/models/chkpointdata.py
+++ b/mdc/models/chkpointdata.py
@@ -181,6 +181,11 @@ class DataWIn(models.Model):
                         _logger.info(
                             '[mdc.data_win] get_average_data WOUT %s - datetime_in: %s - datetime_out: %s - diff.: %s'
                             % (w_numwout, wi.create_datetime, wo.create_datetime, dif_hours))
+        else:
+            _logger.error(
+                '[mdc.data_win] get_average_data not '
+                'found for line_id=%s and lot_id=%s' %
+                (context['line_id'], context['lot_id']))
 
         # calculate de average of the weight
         if w_numwin > 0:
@@ -198,7 +203,7 @@ class DataWIn(models.Model):
                      'numwin:%s - tare: %s - weight: %s - uom: %s'
                      % (context['lot_id'], context['line_id'], w_timewout, w_numwout, w_create_datetime, w_numwin,
                         w_tare, w_weight, w_uom_id))
-        return {
+        return w_tare and {
             'create_datetime': w_create_datetime or fields.Datetime.now(),
             'tare': w_tare,
             'weight': w_weight,
@@ -384,6 +389,13 @@ class DataWOut(models.Model):
                     """
                     joker_win_data = self.env['mdc.data_win'].get_average_data({
                         'lot_id': values['lot_id'], 'line_id': values['line_id']})
+                    if not joker_win_data:
+                        joker_card_lot = \
+                            self.env['mdc.lot'].browse(values['lot_id'])
+                        raise UserError(_(
+                            "Invalid joker card #%s. Before using it, "
+                            "please make at least an input for this line "
+                            "with lot %s") % (card.name, joker_card_lot.name))
                     joker_win_data['lot_id'] = values['lot_id']
                     joker_win_data['line_id'] = values['line_id']
                     joker_win_data['card_id'] = card.id


### PR DESCRIPTION
This error fires when using a joker card within an output if the joker card is assigned to a lot without any inputs in the current line. Before this fix, a python error was thrown; after this, a friendly error is shown instead.

`i18n` files updated too