### PR TITLE
[11.0][IMP] mdc: manual worksheet open & close flag

### DIFF
--- a/mdc/__manifest__.py
+++ b/mdc/__manifest__.py
@@ -14,7 +14,7 @@
 
     'category': 'Manufacturing',
     'license': 'LGPL-3',
-    'version': '1.1',
+    'version': '1.2',
 
     'depends': ['base', 'product', 'hr', 'hr_contract', 'stock', 'report_xlsx', 'base_external_dbsource_mysql'],
 

--- a/mdc/i18n/es.po
+++ b/mdc/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-27 16:33+0000\n"
-"PO-Revision-Date: 2020-04-27 16:33+0000\n"
+"POT-Creation-Date: 2020-04-28 08:58+0000\n"
+"PO-Revision-Date: 2020-04-28 08:58+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -471,6 +471,24 @@ msgid "Cannot create open worksheet: employee %s is already present"
 msgstr "No es podible abrir fichaje: el empleado %s ya está presente"
 
 #. module: mdc
+#: code:addons/mdc/models/morders.py:798
+#, python-format
+msgid "Cannot set manual close to a worksheet with physical close for employee %s"
+msgstr "No se puede marcar el fichaje como cierre manual con cierre físico para el empleado %s"
+
+#. module: mdc
+#: code:addons/mdc/models/morders.py:803
+#, python-format
+msgid "Cannot set manual close to a worksheet without End datetime for employee %s"
+msgstr "No se puede marcar el fichaje como cierre manual sin fecha fin para el empleado %s"
+
+#. module: mdc
+#: code:addons/mdc/models/morders.py:792
+#, python-format
+msgid "Cannot set manual open to a worksheet with physical open for employee %s"
+msgstr "No se puede marcar el fichaje como inicio manual con inicio físico para el empleado %s"
+
+#. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 msgid "Capture Data"
@@ -505,7 +523,7 @@ msgid "Card #%s is not a joker card!"
 msgstr "La Tarjeta #%s no es una tarjeta comodín!"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1013
+#: code:addons/mdc/models/morders.py:1037
 #, python-format
 msgid "Card #%s is not an employee one"
 msgstr "La Tarjeta #%s no es de empleado"
@@ -755,7 +773,7 @@ msgid "Color Index"
 msgstr "Índice de color"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1171
+#: code:addons/mdc/models/morders.py:1195
 #: sql_constraint:mdc.lot_chkpoint:0
 #, python-format
 msgid "Combination: Checkpoint & Shift, are unique, and already Exists!"
@@ -3317,7 +3335,7 @@ msgid "Unknown card #%s"
 msgstr "Tarjeta desconocida #%s"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1015
+#: code:addons/mdc/models/morders.py:1039
 #, python-format
 msgid "Unknown card code #%s"
 msgstr "Código de tarjeta desconocido #%s"
@@ -3608,7 +3626,7 @@ msgstr "YELOWFIN COLAS "
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:38
-#: code:addons/mdc/models/morders.py:797
+#: code:addons/mdc/models/morders.py:818
 #, python-format
 msgid "You are not allowed to change this values"
 msgstr "No tiene permiso para cambiar este valor"
@@ -3668,7 +3686,7 @@ msgid "You can´t change this end datetime. You must change the start date of th
 msgstr "No se puede cambiar esta fecha fin. Se debe cambiar la fecha de inicio del lote activo con la fecha de inicio con esta fecha de fin"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1200
+#: code:addons/mdc/models/morders.py:1224
 #, python-format
 msgid "You can´t establish a future datetime"
 msgstr "No se puede proporcionar una fecha futura"
@@ -3681,19 +3699,19 @@ msgstr "No se puede proporcionar una fecha de fin future"
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:288
-#: code:addons/mdc/models/morders.py:1248
+#: code:addons/mdc/models/morders.py:1272
 #, python-format
 msgid "You can´t give a future start date"
 msgstr "No se puede proporcionar una fecha futura de inicio"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1205
+#: code:addons/mdc/models/morders.py:1229
 #, python-format
 msgid "You can´t give a lot in create mode"
 msgstr "No se puede poner el lote en el alta del registro"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1209
+#: code:addons/mdc/models/morders.py:1233
 #, python-format
 msgid "You can´t give a start lot datetime in create mode"
 msgstr "No se puede poner la fecha de inicio en el alta del registro"
@@ -3743,7 +3761,7 @@ msgid "You must select an employee for this card or select another category"
 msgstr "Debe seleccionar un operario para esta tarjeta o elegir otro tipo"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1216
+#: code:addons/mdc/models/morders.py:1240
 #, python-format
 msgid "You must to have no lot assigned to delete this record"
 msgstr "No se puede tener un lote asignado para borrar el registro"

--- a/mdc/i18n/es.po
+++ b/mdc/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-21 10:38+0000\n"
-"PO-Revision-Date: 2020-04-21 10:38+0000\n"
+"POT-Creation-Date: 2020-04-27 16:33+0000\n"
+"PO-Revision-Date: 2020-04-27 16:33+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -459,13 +459,13 @@ msgid "Cannot cancel input '%s - %s - %s' because it's been already linked with 
 msgstr "No puede cancelar la entrada '%s - %s - %s' porque ha sido vinculada a una salida"
 
 #. module: mdc
-#: code:addons/mdc/models/hr.py:196
+#: code:addons/mdc/models/hr.py:200
 #, python-format
 msgid "Cannot create close worksheet: employee %s is not present"
 msgstr "No es posible cerrar fichaje: el empleado %s no está presente"
 
 #. module: mdc
-#: code:addons/mdc/models/hr.py:184
+#: code:addons/mdc/models/hr.py:185
 #, python-format
 msgid "Cannot create open worksheet: employee %s is already present"
 msgstr "No es podible abrir fichaje: el empleado %s ya está presente"
@@ -505,7 +505,7 @@ msgid "Card #%s is not a joker card!"
 msgstr "La Tarjeta #%s no es una tarjeta comodín!"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1009
+#: code:addons/mdc/models/morders.py:1013
 #, python-format
 msgid "Card #%s is not an employee one"
 msgstr "La Tarjeta #%s no es de empleado"
@@ -755,7 +755,7 @@ msgid "Color Index"
 msgstr "Índice de color"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1167
+#: code:addons/mdc/models/morders.py:1171
 #: sql_constraint:mdc.lot_chkpoint:0
 #, python-format
 msgid "Combination: Checkpoint & Shift, are unique, and already Exists!"
@@ -1244,7 +1244,7 @@ msgstr "Hora final"
 #. module: mdc
 #: code:addons/mdc/models/morders.py:194
 #: code:addons/mdc/models/morders.py:302
-#: code:addons/mdc/models/morders.py:609
+#: code:addons/mdc/models/morders.py:613
 #, python-format
 msgid "End date must be older than start date"
 msgstr "Fecha Fin debe ser posterior a Fecha Inicio"
@@ -1611,15 +1611,15 @@ msgid "Is operator"
 msgstr "Es operario"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:664
-#: code:addons/mdc/models/morders.py:778
+#: code:addons/mdc/models/morders.py:668
+#: code:addons/mdc/models/morders.py:782
 #, python-format
 msgid "It can´t be end datetime less than start date to employee %s"
 msgstr "No es posible fecha-hora final menor que fecha-hora inicial para el empleado %s"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:657
-#: code:addons/mdc/models/morders.py:773
+#: code:addons/mdc/models/morders.py:661
+#: code:addons/mdc/models/morders.py:777
 #, python-format
 msgid "It can´t be start datetime less than last end datetime to employee %s"
 msgstr "No es posible fecha-hora inicial menor que última fecha-hora final para el empleado %s"
@@ -1926,6 +1926,16 @@ msgid "Lots default life in days"
 msgstr "Días de vida por defecto de los lotes"
 
 #. module: mdc
+#: model:ir.ui.view,arch_db:mdc.mdc_worksheets_tree
+msgid "M.C."
+msgstr "C.M."
+
+#. module: mdc
+#: model:ir.ui.view,arch_db:mdc.mdc_worksheets_tree
+msgid "M.O."
+msgstr "I.M."
+
+#. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:466
 #, python-format
 msgid "MANUFACTURING REPORT"
@@ -2032,6 +2042,26 @@ msgstr "Formato de OF no correcto. El formato correcto es NNNNN/AA (NNNNN=númer
 #, python-format
 msgid "MO."
 msgstr "MO."
+
+#. module: mdc
+#: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_manual_close
+msgid "Manual Close"
+msgstr "Cierre manual"
+
+#. module: mdc
+#: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_manual_open
+msgid "Manual Open"
+msgstr "Inicio manual"
+
+#. module: mdc
+#: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
+msgid "Manual close"
+msgstr "Cierre manual"
+
+#. module: mdc
+#: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
+msgid "Manual open"
+msgstr "Inicio manual"
 
 #. module: mdc
 #: model:ir.actions.act_window,name:mdc.action_mdc_rpt_manufacturing
@@ -3113,7 +3143,7 @@ msgid "The selected lot name already exists"
 msgstr "El nombre de lote seleccionado ya existe"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:660
+#: code:addons/mdc/models/morders.py:664
 #, python-format
 msgid "The start date has to be filled"
 msgstr "Debe rellenar la Fecha de Inicio"
@@ -3287,7 +3317,7 @@ msgid "Unknown card #%s"
 msgstr "Tarjeta desconocida #%s"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1011
+#: code:addons/mdc/models/morders.py:1015
 #, python-format
 msgid "Unknown card code #%s"
 msgstr "Código de tarjeta desconocido #%s"
@@ -3578,7 +3608,7 @@ msgstr "YELOWFIN COLAS "
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:38
-#: code:addons/mdc/models/morders.py:793
+#: code:addons/mdc/models/morders.py:797
 #, python-format
 msgid "You are not allowed to change this values"
 msgstr "No tiene permiso para cambiar este valor"
@@ -3614,7 +3644,7 @@ msgid "You can register and track weighing scales."
 msgstr "Puede registrar y testear básculas."
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:753
+#: code:addons/mdc/models/morders.py:757
 #, python-format
 msgid "You can´t change employee form a datasheet."
 msgstr "No puede cambiar el empleado desde un fichaje."
@@ -3638,7 +3668,7 @@ msgid "You can´t change this end datetime. You must change the start date of th
 msgstr "No se puede cambiar esta fecha fin. Se debe cambiar la fecha de inicio del lote activo con la fecha de inicio con esta fecha de fin"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1196
+#: code:addons/mdc/models/morders.py:1200
 #, python-format
 msgid "You can´t establish a future datetime"
 msgstr "No se puede proporcionar una fecha futura"
@@ -3651,19 +3681,19 @@ msgstr "No se puede proporcionar una fecha de fin future"
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:288
-#: code:addons/mdc/models/morders.py:1244
+#: code:addons/mdc/models/morders.py:1248
 #, python-format
 msgid "You can´t give a future start date"
 msgstr "No se puede proporcionar una fecha futura de inicio"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1201
+#: code:addons/mdc/models/morders.py:1205
 #, python-format
 msgid "You can´t give a lot in create mode"
 msgstr "No se puede poner el lote en el alta del registro"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1205
+#: code:addons/mdc/models/morders.py:1209
 #, python-format
 msgid "You can´t give a start lot datetime in create mode"
 msgstr "No se puede poner la fecha de inicio en el alta del registro"
@@ -3713,7 +3743,7 @@ msgid "You must select an employee for this card or select another category"
 msgstr "Debe seleccionar un operario para esta tarjeta o elegir otro tipo"
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1212
+#: code:addons/mdc/models/morders.py:1216
 #, python-format
 msgid "You must to have no lot assigned to delete this record"
 msgstr "No se puede tener un lote asignado para borrar el registro"

--- a/mdc/i18n/mdc.pot
+++ b/mdc/i18n/mdc.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-21 10:38+0000\n"
-"PO-Revision-Date: 2020-04-21 10:38+0000\n"
+"POT-Creation-Date: 2020-04-27 16:31+0000\n"
+"PO-Revision-Date: 2020-04-27 16:31+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -433,13 +433,13 @@ msgid "Cannot cancel input '%s - %s - %s' because it's been already linked with 
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/hr.py:196
+#: code:addons/mdc/models/hr.py:200
 #, python-format
 msgid "Cannot create close worksheet: employee %s is not present"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/hr.py:184
+#: code:addons/mdc/models/hr.py:185
 #, python-format
 msgid "Cannot create open worksheet: employee %s is already present"
 msgstr ""
@@ -479,7 +479,7 @@ msgid "Card #%s is not a joker card!"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1009
+#: code:addons/mdc/models/morders.py:1013
 #, python-format
 msgid "Card #%s is not an employee one"
 msgstr ""
@@ -729,7 +729,7 @@ msgid "Color Index"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1167
+#: code:addons/mdc/models/morders.py:1171
 #: sql_constraint:mdc.lot_chkpoint:0
 #, python-format
 msgid "Combination: Checkpoint & Shift, are unique, and already Exists!"
@@ -1215,7 +1215,7 @@ msgstr ""
 #. module: mdc
 #: code:addons/mdc/models/morders.py:194
 #: code:addons/mdc/models/morders.py:302
-#: code:addons/mdc/models/morders.py:609
+#: code:addons/mdc/models/morders.py:613
 #, python-format
 msgid "End date must be older than start date"
 msgstr ""
@@ -1579,15 +1579,15 @@ msgid "Is operator"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:664
-#: code:addons/mdc/models/morders.py:778
+#: code:addons/mdc/models/morders.py:668
+#: code:addons/mdc/models/morders.py:782
 #, python-format
 msgid "It can´t be end datetime less than start date to employee %s"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:657
-#: code:addons/mdc/models/morders.py:773
+#: code:addons/mdc/models/morders.py:661
+#: code:addons/mdc/models/morders.py:777
 #, python-format
 msgid "It can´t be start datetime less than last end datetime to employee %s"
 msgstr ""
@@ -1894,6 +1894,16 @@ msgid "Lots default life in days"
 msgstr ""
 
 #. module: mdc
+#: model:ir.ui.view,arch_db:mdc.mdc_worksheets_tree
+msgid "M.C."
+msgstr ""
+
+#. module: mdc
+#: model:ir.ui.view,arch_db:mdc.mdc_worksheets_tree
+msgid "M.O."
+msgstr ""
+
+#. module: mdc
 #: code:addons/mdc/report/report_xlsx.py:466
 #, python-format
 msgid "MANUFACTURING REPORT"
@@ -1999,6 +2009,26 @@ msgstr ""
 #: code:addons/mdc/report/report_xlsx.py:1024
 #, python-format
 msgid "MO."
+msgstr ""
+
+#. module: mdc
+#: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_manual_close
+msgid "Manual Close"
+msgstr ""
+
+#. module: mdc
+#: model:ir.model.fields,field_description:mdc.field_mdc_worksheet_manual_open
+msgid "Manual Open"
+msgstr ""
+
+#. module: mdc
+#: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
+msgid "Manual close"
+msgstr ""
+
+#. module: mdc
+#: model:ir.ui.view,arch_db:mdc.mdc_worksheets_search
+msgid "Manual open"
 msgstr ""
 
 #. module: mdc
@@ -3072,7 +3102,7 @@ msgid "The selected lot name already exists"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:660
+#: code:addons/mdc/models/morders.py:664
 #, python-format
 msgid "The start date has to be filled"
 msgstr ""
@@ -3246,7 +3276,7 @@ msgid "Unknown card #%s"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1011
+#: code:addons/mdc/models/morders.py:1015
 #, python-format
 msgid "Unknown card code #%s"
 msgstr ""
@@ -3537,7 +3567,7 @@ msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:38
-#: code:addons/mdc/models/morders.py:793
+#: code:addons/mdc/models/morders.py:797
 #, python-format
 msgid "You are not allowed to change this values"
 msgstr ""
@@ -3573,7 +3603,7 @@ msgid "You can register and track weighing scales."
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:753
+#: code:addons/mdc/models/morders.py:757
 #, python-format
 msgid "You can´t change employee form a datasheet."
 msgstr ""
@@ -3597,7 +3627,7 @@ msgid "You can´t change this end datetime. You must change the start date of th
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1196
+#: code:addons/mdc/models/morders.py:1200
 #, python-format
 msgid "You can´t establish a future datetime"
 msgstr ""
@@ -3610,19 +3640,19 @@ msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:288
-#: code:addons/mdc/models/morders.py:1244
+#: code:addons/mdc/models/morders.py:1248
 #, python-format
 msgid "You can´t give a future start date"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1201
+#: code:addons/mdc/models/morders.py:1205
 #, python-format
 msgid "You can´t give a lot in create mode"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1205
+#: code:addons/mdc/models/morders.py:1209
 #, python-format
 msgid "You can´t give a start lot datetime in create mode"
 msgstr ""
@@ -3672,7 +3702,7 @@ msgid "You must select an employee for this card or select another category"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1212
+#: code:addons/mdc/models/morders.py:1216
 #, python-format
 msgid "You must to have no lot assigned to delete this record"
 msgstr ""

--- a/mdc/i18n/mdc.pot
+++ b/mdc/i18n/mdc.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-27 16:31+0000\n"
-"PO-Revision-Date: 2020-04-27 16:31+0000\n"
+"POT-Creation-Date: 2020-04-28 09:00+0000\n"
+"PO-Revision-Date: 2020-04-28 09:00+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -445,6 +445,24 @@ msgid "Cannot create open worksheet: employee %s is already present"
 msgstr ""
 
 #. module: mdc
+#: code:addons/mdc/models/morders.py:798
+#, python-format
+msgid "Cannot set manual close to a worksheet with physical close for employee %s"
+msgstr ""
+
+#. module: mdc
+#: code:addons/mdc/models/morders.py:803
+#, python-format
+msgid "Cannot set manual close to a worksheet without End datetime for employee %s"
+msgstr ""
+
+#. module: mdc
+#: code:addons/mdc/models/morders.py:792
+#, python-format
+msgid "Cannot set manual open to a worksheet with physical open for employee %s"
+msgstr ""
+
+#. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wins_form
 #: model:ir.ui.view,arch_db:mdc.mdc_data_wouts_form
 msgid "Capture Data"
@@ -479,7 +497,7 @@ msgid "Card #%s is not a joker card!"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1013
+#: code:addons/mdc/models/morders.py:1037
 #, python-format
 msgid "Card #%s is not an employee one"
 msgstr ""
@@ -729,7 +747,7 @@ msgid "Color Index"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1171
+#: code:addons/mdc/models/morders.py:1195
 #: sql_constraint:mdc.lot_chkpoint:0
 #, python-format
 msgid "Combination: Checkpoint & Shift, are unique, and already Exists!"
@@ -3276,7 +3294,7 @@ msgid "Unknown card #%s"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1015
+#: code:addons/mdc/models/morders.py:1039
 #, python-format
 msgid "Unknown card code #%s"
 msgstr ""
@@ -3567,7 +3585,7 @@ msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:38
-#: code:addons/mdc/models/morders.py:797
+#: code:addons/mdc/models/morders.py:818
 #, python-format
 msgid "You are not allowed to change this values"
 msgstr ""
@@ -3627,7 +3645,7 @@ msgid "You can´t change this end datetime. You must change the start date of th
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1200
+#: code:addons/mdc/models/morders.py:1224
 #, python-format
 msgid "You can´t establish a future datetime"
 msgstr ""
@@ -3640,19 +3658,19 @@ msgstr ""
 
 #. module: mdc
 #: code:addons/mdc/models/morders.py:288
-#: code:addons/mdc/models/morders.py:1248
+#: code:addons/mdc/models/morders.py:1272
 #, python-format
 msgid "You can´t give a future start date"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1205
+#: code:addons/mdc/models/morders.py:1229
 #, python-format
 msgid "You can´t give a lot in create mode"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1209
+#: code:addons/mdc/models/morders.py:1233
 #, python-format
 msgid "You can´t give a start lot datetime in create mode"
 msgstr ""
@@ -3702,7 +3720,7 @@ msgid "You must select an employee for this card or select another category"
 msgstr ""
 
 #. module: mdc
-#: code:addons/mdc/models/morders.py:1216
+#: code:addons/mdc/models/morders.py:1240
 #, python-format
 msgid "You must to have no lot assigned to delete this record"
 msgstr ""

--- a/mdc/models/morders.py
+++ b/mdc/models/morders.py
@@ -563,6 +563,10 @@ class Worksheet(models.Model):
         default = _default_date)
     end_datetime = fields.Datetime(
         'End Datetime')
+    manual_open = fields.Boolean(
+        default=False)
+    manual_close = fields.Boolean(
+        default=False)
     physical_open = fields.Boolean(
         'Physical open',
         default=False)

--- a/mdc/views/data_views.xml
+++ b/mdc/views/data_views.xml
@@ -15,6 +15,9 @@
                 <separator/>
                 <filter name="physical_open" string="Physical open" domain="[('physical_open', '=', True)]"/>
                 <filter name="physical_close" string="Physical close" domain="[('physical_close', '=', True)]"/>
+                <separator/>
+                <filter name="manual_open" string="Manual open" domain="[('manual_open', '=', True)]"/>
+                <filter name="manual_close" string="Manual close" domain="[('manual_close', '=', True)]"/>
                 <group expand="0" string="Group By">
                     <filter string="Employee" name="groupby_employee" domain="[]" context="{'group_by':'employee_id'}"/>
                     <filter string="Lot" name="groupby_lot" domain="[]" context="{'group_by':'lot_id'}"/>
@@ -32,8 +35,10 @@
                 <field name="employee_id"/>
                 <field name="start_datetime"/>
                 <field name="physical_open" string="P.O."/>
+                <field name="manual_open" string="M.O."/>
                 <field name="end_datetime"/>
                 <field name="physical_close" string="P.C."/>
+                <field name="manual_close" string="M.C."/>
                 <field name="lot_id"/>
                 <field name="workstation_id"/>
                 <field name="shift_id"/>
@@ -74,10 +79,12 @@
                         <group>
                             <field name="physical_open" readonly="True"/>
                             <field name="physical_start_datetime" readonly="True"/>
+                            <field name="manual_open" readonly="True"/>
                         </group>
                         <group>
                             <field name="physical_close" readonly="True"/>
                             <field name="physical_end_datetime" readonly="True"/>
+                            <field name="manual_close" readonly="True"/>
                         </group>
                     </group>
                 </sheet>

--- a/mdc/views/data_views.xml
+++ b/mdc/views/data_views.xml
@@ -72,6 +72,8 @@
                             <field name="workstation_id"/>
                         </group>
                         <group>
+                            <field name="manual_open"/>
+                            <field name="manual_close"/>
                             <field name="total_hours" readonly="True"/>
                         </group>
                     </group>
@@ -79,12 +81,10 @@
                         <group>
                             <field name="physical_open" readonly="True"/>
                             <field name="physical_start_datetime" readonly="True"/>
-                            <field name="manual_open" readonly="True"/>
                         </group>
                         <group>
                             <field name="physical_close" readonly="True"/>
                             <field name="physical_end_datetime" readonly="True"/>
-                            <field name="manual_close" readonly="True"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
This improvement create new flags for a worksheet, which are filled when a massive open or close worksheets action is fired. With these flags it's possible to determine whether a worksheet was manually created, instead of a physical one