### PR TITLE
[11.0][FIX] mdc_rpt_indicators_by_employee: prevent null employee_code

### DIFF
--- a/mdc_rpt_indicators_by_employee/report/report.py
+++ b/mdc_rpt_indicators_by_employee/report/report.py
@@ -51,7 +51,8 @@ class RptIndicatorsByEmployee(models.Model):
                             + (0.1 * mdcdata.quality_weight/(mdcdata.product_weight + mdcdata.shared_product_weight/2)) end as ind_cleaning 
                             FROM (
                                 SELECT woutdata.id, woutdata.create_date, 
-                                    emp.employee_code, emp.name as employee_name, line.line_code, shift.shift_code, woutdata.lot_id, 
+                                    coalesce(emp.employee_code, concat('Emp. id #', emp.id)) employee_code, 
+                                    emp.name as employee_name, line.line_code, shift.shift_code, woutdata.lot_id, 
                                     case when (lot.finished and (lot.weight > 0) and (lot.total_gross_weight/lot.weight)<>0) then woutdata.gross_weight/(lot.total_gross_weight/lot.weight) when (1-coalesce(lot.std_loss,0)/100) = 0 then 999999 else woutdata.gross_weight /(1-coalesce(lot.std_loss,0)/100) end as gross_weight_reference,
                                     woutdata.gross_weight, woutdata.product_weight, woutdata.sp1_weight, 
                                     case when (1-coalesce(lot.std_loss,0)/100) = 0 then 999999 else woutdata.shared_gross_weight /(1-coalesce(lot.std_loss,0)/100) end as shared_gross_weight_reference,


### PR DESCRIPTION
Prevent null value for employee_code (when this code is null the export to excel fails in the sorting by this code)