### PR TITLE
[11.0] [IMP] mdc: input data cancel mode fixedtime

### DIFF
--- a/mdc/__manifest__.py
+++ b/mdc/__manifest__.py
@@ -14,7 +14,7 @@
 
     'category': 'Manufacturing',
     'license': 'LGPL-3',
-    'version': '11.0.1.5.0',
+    'version': '11.0.1.6.0',
 
     'depends': ['base', 'product', 'hr', 'hr_contract', 'stock', 'report_xlsx', 'base_external_dbsource_mysql'],
 

--- a/mdc/i18n/es.po
+++ b/mdc/i18n/es.po
@@ -21,11 +21,15 @@ msgid "\n"
 "        Selects how the input cancel cron will be perform the old unlinked inputs expiration:\n"
 "        - 1-day old (default): when an input is 24 hours old or more\n"
 "        - yesterday: when an input belongs to a previous day than today\n"
+"        - fixedtime: input cancel cron runs only once a day at a fixed time\n"
+"                     and cancel all inputs without an output less than this fixed time\n"
 "        "
 msgstr "\n"
 "        Permite seleccionar cómo se comportará la tarea planificada que cancela las entradas no enlazadas antiguas:\n"
 "        - Antigüedad de 1 día (por defecto): cuando una entrada tiene 24 horas de antigüedad o más\n"
 "        - Día anterior: cuando una entrada pertenece a un día anterior a hoy\n"
+"        - A una hora fija: el proceso de cancelación de entradas se ejecuta a una hora determinada\n"
+"                     y cancela todas las entradas sin salida menores a esa hora determinada\n"
 "        "
 
 #. module: mdc
@@ -1599,6 +1603,11 @@ msgstr "Entrada"
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_data_win_cancel_mode
 msgid "Input data cancel mode"
 msgstr "Modo de cancelación para entradas"
+
+#. module: mdc
+#: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_data_win_cancel_fixed_time
+msgid "Next date for input cancel cron and cancel inputs without an output less than this time"
+msgstr "Próxima fecha-hora de ejecución de proceso de cancelación de entradas (cancelando entradas sin salida anteriores a esta fecha-hora)"
 
 #. module: mdc
 #: model:ir.ui.view,arch_db:mdc.mdc_config_settings_view_form
@@ -3672,6 +3681,11 @@ msgstr "YELOWFIN COLAS "
 #: selection:mdc.config.settings,data_win_cancel_mode:0
 msgid "Yesterday"
 msgstr "Día anterior"
+
+#. module: mdc
+#: selection:mdc.config.settings,data_win_cancel_mode:0
+msgid "Fixed time"
+msgstr "A una hoja fija"
 
 #. module: mdc
 #: code:addons/mdc/models/mdc_config_settings.py:49

--- a/mdc/i18n/mdc.pot
+++ b/mdc/i18n/mdc.pot
@@ -21,6 +21,8 @@ msgid "\n"
 "        Selects how the input cancel cron will be perform the old unlinked inputs expiration:\n"
 "        - 1-day old (default): when an input is 24 hours old or more\n"
 "        - yesterday: when an input belongs to a previous day than today\n"
+"        - fixedtime: input cancel cron runs only once a day at a fixed time\n"
+"                     and cancel all inputs without an output less than this fixed time\n"
 "        "
 msgstr ""
 
@@ -1562,6 +1564,11 @@ msgstr ""
 #. module: mdc
 #: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_data_win_cancel_mode
 msgid "Input data cancel mode"
+msgstr ""
+
+#. module: mdc
+#: model:ir.model.fields,field_description:mdc.field_mdc_config_settings_data_win_cancel_fixed_time
+msgid "Next date for input cancel cron and cancel inputs without an output less than this time"
 msgstr ""
 
 #. module: mdc
@@ -3626,6 +3633,11 @@ msgstr ""
 #. module: mdc
 #: selection:mdc.config.settings,data_win_cancel_mode:0
 msgid "Yesterday"
+msgstr ""
+
+#. module: mdc
+#: selection:mdc.config.settings,data_win_cancel_mode:0
+msgid "Fixed time"
 msgstr ""
 
 #. module: mdc

--- a/mdc/models/mdc_config_settings.py
+++ b/mdc/models/mdc_config_settings.py
@@ -14,14 +14,19 @@ class MdcConfigSettings(models.TransientModel):
     lot_default_life_days = fields.Char('Lots default life in days')
     lot_last_total_gross_weight_update_timestamp = fields.Char('Lot last total gross weight update timestamp')
     data_win_cancel_mode = fields.Selection(
-        selection=[('oneday', '1-day old'), ('yesterday', 'Yesterday')],
+        selection=[('oneday', '1-day old'), ('yesterday', 'Yesterday'), ('fixedtime', 'Fixed time')],
         string="Input data cancel mode",
         help="""
         Selects how the input cancel cron will be perform the old unlinked inputs expiration:
         - 1-day old (default): when an input is 24 hours old or more
         - yesterday: when an input belongs to a previous day than today
+        - fixedtime: input cancel cron runs only once a day at a fixed time 
+                     and cancel all inputs without an output less than this fixed time
         """,
         default='oneday',
+    )
+    data_win_cancel_fixed_time = fields.Datetime(
+        'Next date for input cancel cron and cancel inputs without an output less than this time'
     )
     rpt_hide_shift_change_data = fields.Boolean(
         'Hide shift change data in Reports',
@@ -42,6 +47,7 @@ class MdcConfigSettings(models.TransientModel):
             lot_default_life_days=IrConfigParameter.get_param('mdc.lot_default_life_days'),
             lot_last_total_gross_weight_update_timestamp=IrConfigParameter.get_param('mdc.lot_last_total_gross_weight_update_timestamp'),
             data_win_cancel_mode=IrConfigParameter.get_param('mdc.data_win_cancel_mode'),
+            data_win_cancel_fixed_time=IrConfigParameter.get_param('mdc.data_win_cancel_fixed_time'),
             rpt_hide_shift_change_data=IrConfigParameter.get_param('mdc.rpt_hide_shift_change_data'),
         )
         return res
@@ -74,4 +80,5 @@ class MdcConfigSettings(models.TransientModel):
         IrConfigParameter.set_param('mdc.rfid_server_min_secs_between_worksheets', self.rfid_server_min_secs_between_worksheets)
         IrConfigParameter.set_param('mdc.lot_default_life_days', self.lot_default_life_days)
         IrConfigParameter.set_param('mdc.data_win_cancel_mode', self.data_win_cancel_mode)
+        IrConfigParameter.set_param('mdc.data_win_cancel_fixed_time', self.data_win_cancel_fixed_time)
         IrConfigParameter.set_param('mdc.rpt_hide_shift_change_data', self.rpt_hide_shift_change_data)

--- a/mdc/views/mdc_config_settings.xml
+++ b/mdc/views/mdc_config_settings.xml
@@ -59,6 +59,13 @@
                             <label for="data_win_cancel_mode"/>
                             <field name="data_win_cancel_mode" required="True"/>
                         </div>
+                        <div>
+                            <label for="data_win_cancel_fixed_time"
+                                   attrs="{'invisible': [('data_win_cancel_mode', '!=', 'fixedtime')]}"/>
+                            <field name="data_win_cancel_fixed_time"
+                                   attrs="{'invisible': [('data_win_cancel_mode', '!=', 'fixedtime')],
+                                   'required': [('data_win_cancel_mode', '=', 'fixedtime')]}"/>
+                        </div>
                     </div>
                 </group>
                 <group name="reports_params_group" string="Report configuration parameters">


### PR DESCRIPTION
New cancel mode: fixedtime: input cancel cron runs only once a day at a fixed time and cancel all inputs without an output less than this fixed time